### PR TITLE
add a flake to typecheck agda files and add a ci to run it

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,14 @@
+name: "Typecheck with agda"
+on:
+  pull_request:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v22
+      with:
+        nix_path: nixpkgs=https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre568310.eabe8d3eface/nixexprs.tar.xz
+    - uses: DeterminateSystems/magic-nix-cache-action@v2
+    - run: nix build --print-build-logs

--- a/flake.lock
+++ b/flake.lock
@@ -36,16 +36,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705007420,
-        "narHash": "sha256-07K3yiVgVavQ2w+C6+ZMsjWXs1ldoECHEkdnSGBHt6o=",
+        "lastModified": 1704842529,
+        "narHash": "sha256-OTeQA+F8d/Evad33JMfuXC89VMetQbsU4qcaePchGr4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7574dde16a966f759a7507f615210253cc892ac",
+        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
+        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "agda2hs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705008391,
+        "narHash": "sha256-jC21WrmnjiL+ZTC/GG0xumQa7zjqp6qR2WppDR26jhw=",
+        "owner": "liesnikov",
+        "repo": "agda2hs",
+        "rev": "9957295e9c0447e24fd73465a38e80dd75f74562",
+        "type": "github"
+      },
+      "original": {
+        "owner": "liesnikov",
+        "repo": "agda2hs",
+        "rev": "9957295e9c0447e24fd73465a38e80dd75f74562",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1705007420,
+        "narHash": "sha256-07K3yiVgVavQ2w+C6+ZMsjWXs1ldoECHEkdnSGBHt6o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d7574dde16a966f759a7507f615210253cc892ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "agda2hs-src": "agda2hs-src",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "scope-src": "scope-src"
+      }
+    },
+    "scope-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705008827,
+        "narHash": "sha256-mI/K6wPR9FZEYyZbAGyZOtsMSTNHciusHEiNKJzzwSU=",
+        "owner": "liesnikov",
+        "repo": "scope",
+        "rev": "5890c20e26b0ce9cf9d31c9d3ec39f71ddebd236",
+        "type": "github"
+      },
+      "original": {
+        "owner": "liesnikov",
+        "repo": "scope",
+        "rev": "5890c20e26b0ce9cf9d31c9d3ec39f71ddebd236",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -3,17 +3,16 @@
     "agda2hs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1705008391,
-        "narHash": "sha256-jC21WrmnjiL+ZTC/GG0xumQa7zjqp6qR2WppDR26jhw=",
-        "owner": "liesnikov",
+        "lastModified": 1703776398,
+        "narHash": "sha256-oWNrEFw6gcSu7GxUbHBP4iwXMNQQnxhLm4rhBwLvXvs=",
+        "owner": "agda",
         "repo": "agda2hs",
-        "rev": "9957295e9c0447e24fd73465a38e80dd75f74562",
+        "rev": "5acd4eb9d718ce58411ff103b8ae1f4f99d032c9",
         "type": "github"
       },
       "original": {
-        "owner": "liesnikov",
+        "owner": "agda",
         "repo": "agda2hs",
-        "rev": "9957295e9c0447e24fd73465a38e80dd75f74562",
         "type": "github"
       }
     },
@@ -61,17 +60,16 @@
     "scope-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1705008827,
-        "narHash": "sha256-mI/K6wPR9FZEYyZbAGyZOtsMSTNHciusHEiNKJzzwSU=",
-        "owner": "liesnikov",
+        "lastModified": 1703256567,
+        "narHash": "sha256-ruoUCO7DJXPCWHw+7XlE87qS3zCJ0nMekhfbr4QT2YY=",
+        "owner": "jespercockx",
         "repo": "scope",
-        "rev": "5890c20e26b0ce9cf9d31c9d3ec39f71ddebd236",
+        "rev": "b89172f1aec0b16daf745992a5bc699bcfbfe169",
         "type": "github"
       },
       "original": {
-        "owner": "liesnikov",
+        "owner": "jespercockx",
         "repo": "scope",
-        "rev": "5890c20e26b0ce9cf9d31c9d3ec39f71ddebd236",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Agda core";
 
-  inputs.nixpkgs.url = github:NixOS/nixpkgs;
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/eabe8d3eface69f5bb16c18f8662a702f50c20d5;
   inputs.flake-utils.url = github:numtide/flake-utils;
   inputs.agda2hs-src = {
      type = "github";
@@ -41,7 +41,7 @@
             src = scope-src;
           };
       in {
-        packages = {
+        packages = rec {
           agda-core = agdaDerivation
             { name = "agda-core";
               pname = "agda-core";
@@ -52,8 +52,12 @@
               buildInputs = [ agda2hslib scopelib ];
               src = ./.;
             };
+          default = agda-core;
         };
 
-        defaultPackage = self.packages.${system}.agda-core;
+        devShells.default = pkgs.mkShell {
+          # should also include agda2hs, but not building it for now
+          packages = [ (pkgs.agda.withPackages [ agda2hslib scopelib ]) pkgs.haskell ];
+        };
       }));
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,62 @@
+{
+  description = "Agda core";
+
+  inputs.nixpkgs.url = github:NixOS/nixpkgs;
+  inputs.flake-utils.url = github:numtide/flake-utils;
+  inputs.agda2hs-src = {
+     type = "github";
+     owner = "liesnikov";
+     repo = "agda2hs";
+     rev = "9957295e9c0447e24fd73465a38e80dd75f74562";
+     flake = false;
+  };
+
+  inputs.scope-src = {
+     type = "github";
+     owner = "liesnikov";
+     repo = "scope";
+     rev = "5890c20e26b0ce9cf9d31c9d3ec39f71ddebd236";
+     flake = false;
+   };
+
+  outputs = {self, nixpkgs, flake-utils, agda2hs-src, scope-src}:
+    let
+    in (flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; overlays = []; };
+        agda2hslib = pkgs.agdaPackages.mkDerivation
+          { name = "agda2hslib";
+            pname = "agda2hs";
+            meta = {};
+            version = "1.3";
+            everythingFile = "lib/Haskell/Everything.agda";
+            src = agda2hs-src;
+          };
+        scopelib = pkgs.agdaPackages.mkDerivation
+          { name = "scopelib";
+            pname = "scope";
+            meta = {};
+            version = "0.1.0.0";
+            src = scope-src;
+            everythingFile = "src/Everything.agda";
+            buildInputs = [
+              agda2hslib
+            ];
+          };
+      in {
+        packages = {
+          agda-core = pkgs.agdaPackages.mkDerivation
+            { name = "agda-core";
+              pname = "agda-core";
+              meta = {};
+              libraryName = "agda-core";
+              libraryFile = "core.agda-lib";
+              everythingFile = "src/Typechecker.agda";
+              buildInputs = [ agda2hslib scopelib ];
+              src = ./.;
+            };
+        };
+
+        defaultPackage = self.packages.${system}.agda-core;
+      }));
+}

--- a/flake.nix
+++ b/flake.nix
@@ -19,39 +19,10 @@
 
   outputs = {self, nixpkgs, flake-utils, agda2hs-src, scope-src}:
     let
-      getAttrOrDefault = atr: def: set:
-        if builtins.hasAttr atr set then builtins.getAttr atr set else def;
     in (flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
-        agdaDerivation = args:
-          pkgs.agdaPackages.mkDerivation
-            (args // (if # don't override if Everything is present
-                         args ? everythingFile ||
-                         # don't override if there's an explicit buildPhase
-                         (getAttrOrDefault "buildPhase" null args != null) ||
-                         # do override if either tcFiles or tcDir is present
-                         ! (args ? tcFiles || args ? tcDir)
-                      then builtins.trace "not overriding" {}
-                      else
-                        {buildPhase =
-                           let ipaths = getAttrOrDefault "includePaths" [] args;
-                               concatMapStrings = pkgs.lib.strings.concatMapStrings;
-                               iarg = concatMapStrings (path: "-i" + path + " ") ipaths;
-                           in if args ? tcFiles
-                              then
-                                ''
-                                runHook preBuild
-                                ${concatMapStrings (f: "agda " + iarg + f + ";") args.tcFiles}
-                                runHook postBuild
-                                ''
-                              else
-                                ''
-                                runHook preBuild
-                                find "${args.tcDir}" -type f -name "*.agda" -print0 | xargs -0 -n1 ${"agda" + iarg}
-                                runHook postBuild
-                                ''
-                         ;}));
+        agdaDerivation = pkgs.callPackage ./nix/mkAgdaDerivation.nix {};
         agda2hslib = agdaDerivation
           { pname = "agda2hs";
             meta = {};

--- a/nix/mkAgdaDerivation.nix
+++ b/nix/mkAgdaDerivation.nix
@@ -1,0 +1,32 @@
+{agdaPackages, lib}: args:
+with lib.strings;
+let
+  getAttrOrDefault = atr: def: set:
+    if builtins.hasAttr atr set then builtins.getAttr atr set else def;
+in
+agdaPackages.mkDerivation (args //
+  (if # don't override if Everything.agda is present
+     args ? everythingFile ||
+     # don't override if there's an explicit buildPhase
+     (getAttrOrDefault "buildPhase" null args != null) ||
+     # do override if either tcFiles or tcDir is present
+     ! (args ? tcFiles || args ? tcDir)
+   then builtins.trace "not overriding" {}
+   else
+     {buildPhase =
+        let ipaths = getAttrOrDefault "includePaths" [] args;
+            iarg = concatMapStrings (path: "-i" + path + " ") ipaths;
+        in if args ? tcFiles
+           then
+             ''
+             runHook preBuild
+             ${concatMapStrings (f: "agda " + iarg + f + ";") args.tcFiles}
+             runHook postBuild
+             ''
+           else
+             ''
+             runHook preBuild
+             find "${args.tcDir}" -type f -name "*.agda" -print0 | xargs -0 -n1 -t ${"agda" + iarg}
+             runHook postBuild
+             ''
+      ;}))

--- a/nix/mkAgdaDerivation.nix
+++ b/nix/mkAgdaDerivation.nix
@@ -26,7 +26,7 @@ agdaPackages.mkDerivation (args //
            else
              ''
              runHook preBuild
-             find "${args.tcDir}" -type f -name "*.agda" -print0 | xargs -0 -n1 -t ${"agda" + iarg}
+             find "${args.tcDir}" -type f -name "*.agda" -print0 | xargs -0 -n1 -t -P $(nproc) ${"agda" + iarg}
              runHook postBuild
              ''
       ;}))

--- a/src/Typechecker.agda
+++ b/src/Typechecker.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --allow-unsolved-metas #-}
 open import Scope
 import Syntax
 import Reduce


### PR DESCRIPTION
at the moment build fails because Typechecking.agda has unsolved metas and ScopeTest.agda imports Utils which can't be resolved

this also uses some primitive parallelism with xargs which did speed up things by the factor of two on my machine, but we can also drop it.