### PR TITLE
Change representation of Type

### DIFF
--- a/src/Agda/Core/Context.agda
+++ b/src/Agda/Core/Context.agda
@@ -38,7 +38,7 @@ private variable
 
 lookupVar : (Γ : Context α) (@0 x : name) (p : x ∈ α) → Type α
 lookupVar CtxEmpty x p = inEmptyCase p
-lookupVar (CtxExtend g y s) x p = raise (rezz _) (inBindCase p
+lookupVar (CtxExtend g y s) x p = raiseType (rezz _) (inBindCase p
   (λ _ → s)
   (λ q → lookupVar g x q))
 

--- a/src/Agda/Core/Conversion.agda
+++ b/src/Agda/Core/Conversion.agda
@@ -1,4 +1,4 @@
-open import Haskell.Prelude hiding (All; a; b; c; t)
+open import Haskell.Prelude hiding (All; a; b; c; s; t)
 
 open import Scope
 open import Agda.Core.GlobalScope using (Globals)
@@ -24,13 +24,13 @@ open import Agda.Core.Context globals
 private variable
   @0 x y z          : name
   @0 α β γ          : Scope name
-  @0 t t' u u' v v' : Term α
+  @0 s s' t t' u u' v v' : Term α
   @0 k l n sa sb    : Sort α
   @0 a a' b b' c c' : Type α
   @0 w w'           : Elim α
 
-data Conv     (@0 Γ : Context α) : @0 Type α → @0 Term α → @0 Term α → Set
-data ConvElim (@0 Γ : Context α) : @0 Type α → @0 Term α → @0 Elim α → @0 Elim α → Set
+data Conv     (@0 Γ : Context α) : @0 Term α → @0 Term α → @0 Term α → Set
+data ConvElim (@0 Γ : Context α) : @0 Term α → @0 Term α → @0 Elim α → @0 Elim α → Set
 
 {-# COMPILE AGDA2HS Conv     #-}
 {-# COMPILE AGDA2HS ConvElim #-}
@@ -49,14 +49,14 @@ renameTopE = renameTop (rezz _)
 
 data Conv {α} Γ where
   CRefl  : Γ ⊢ u ≅ u ∶ t
-  CLam   : Γ , x ∶ a ⊢ renameTopE u ≅ renameTopE v ∶ b
-         → Γ ⊢ TLam y u ≅ TLam z v ∶ TPi x k l a b
-  CPi    : Γ ⊢ a ≅ a' ∶ TSort sa
-         → Γ , x ∶ a ⊢ b ≅ renameTopE b' ∶ TSort (weakenSort (subWeaken subRefl) sb)
-         → Γ ⊢ TPi x sa sb a b ≅ TPi y sa sb a' b' ∶ TSort (funSort sa sb)
-  CApp   : Γ ⊢ u ≅ u' ∶ a
-         → Γ ⊢ u [ w ≅ w' ] ∶ a
-         → Γ ⊢ TApp u w ≅ TApp u' w' ∶ b
+  CLam   : Γ , x ∶ a ⊢ renameTopE u ≅ renameTopE v ∶ unType b
+         → Γ ⊢ TLam y u ≅ TLam z v ∶ TPi x a b
+  CPi    : Γ ⊢ unType a ≅ unType a' ∶ TSort (typeSort a)
+         → Γ , x ∶ a ⊢ unType b ≅ renameTopE (unType b') ∶ TSort (typeSort b)
+         → Γ ⊢ TPi x a b ≅ TPi y a' b' ∶ TSort (funSort sa sb)
+  CApp   : Γ ⊢ u ≅ u' ∶ s
+         → Γ ⊢ u [ w ≅ w' ] ∶ t
+         → Γ ⊢ TApp u w ≅ TApp u' w' ∶ t
   CRedT  : @0 ReducesTo sig t t'
          → Γ ⊢ u  ≅ v  ∶ t'
          → Γ ⊢ u  ≅ v  ∶ t
@@ -73,8 +73,8 @@ data ConvElim Γ where
   CERedT : @0 ReducesTo sig t t'
          → Γ ⊢ u [ w ≅ w' ] ∶ t'
          → Γ ⊢ u [ w ≅ w' ] ∶ t
-  CEArg  : Γ ⊢ v ≅ v' ∶ a
-         → Γ ⊢ u [ EArg v ≅ EArg v' ] ∶ TPi x sa sb a b
+  CEArg  : Γ ⊢ v ≅ v' ∶ unType a
+         → Γ ⊢ u [ EArg v ≅ EArg v' ] ∶ TPi x a b
   -- TODO: CEProj : {!   !}
   -- TODO: CECase : {!   !}
 

--- a/src/Agda/Core/Reduce.agda
+++ b/src/Agda/Core/Reduce.agda
@@ -146,7 +146,7 @@ opaque
   step sig (MkState e (TCon c q vs) (EProj f p ∷ s)) = Nothing -- TODO
   step sig (MkState e (TCon c q x) s) = Nothing
   step sig (MkState e (TLam x v) s) = Nothing
-  step sig (MkState e (TPi x sa sb a b) s) = Nothing
+  step sig (MkState e (TPi x a b) s) = Nothing
   step sig (MkState e (TSort n) s) = Nothing
   step sig (MkState e (TAnn u t) s) = Just (MkState e u s) -- TODO preserve annotations on non-inferrable terms
 

--- a/src/Agda/Core/Substitute.agda
+++ b/src/Agda/Core/Substitute.agda
@@ -20,6 +20,7 @@ private variable
 
 substTerm     : α ⇒ β → Term α → Term β
 substSort     : α ⇒ β → Sort α → Sort β
+substType     : α ⇒ β → Type α → Type β
 substElim     : α ⇒ β → Elim α → Elim β
 substElims    : α ⇒ β → Elims α → Elims β
 substBranch   : α ⇒ β → Branch α → Branch β
@@ -29,16 +30,18 @@ substSubst    : α ⇒ β → γ ⇒ α → γ ⇒ β
 substSort f (STyp x) = STyp x
 {-# COMPILE AGDA2HS substSort #-}
 
+substType f (El st t) = El (substSort f st) (substTerm f t)
+{-# COMPILE AGDA2HS substType #-}
+
 substTerm f (TVar x k)        = lookupSubst f x k
 substTerm f (TDef d k)        = TDef d k
 substTerm f (TCon c k vs)     = TCon c k (substSubst f vs)
 substTerm f (TLam x v)        = TLam x (substTerm (liftBindSubst f) v)
 substTerm f (TApp u v)        = TApp (substTerm f u) (substElim f v)
-substTerm f (TPi x sa sb a b) =
-  TPi x (substSort f sa) (substSort f sb) (substTerm f a) (substTerm (liftBindSubst f) b)
+substTerm f (TPi x a b)       = TPi x (substType f a) (substType (liftBindSubst f) b)
 substTerm f (TSort s)         = TSort (substSort f s)
 substTerm f (TLet x u v)      = TLet x (substTerm f u) (substTerm (liftBindSubst f) v)
-substTerm f (TAnn u t)        = TAnn (substTerm f u) (substTerm f t)
+substTerm f (TAnn u t)        = TAnn (substTerm f u) (substType f t)
 {-# COMPILE AGDA2HS substTerm #-}
 
 substElim f (EArg u)    = EArg (substTerm f u)

--- a/src/Agda/Core/Typechecker.agda
+++ b/src/Agda/Core/Typechecker.agda
@@ -33,7 +33,7 @@ private variable
   @0 α : Scope name
 
 postulate
-  convert   : (Γ : Context α) (@0 ty : Type α) (@0 a b : Term α) → Γ ⊢ a ≅ b ∶ ty
+  convert   : (Γ : Context α) (@0 ty : Term α) (@0 a b : Term α) → Γ ⊢ a ≅ b ∶ ty
 
 reduceTo : (_ : Rezz _ α)
            (sig : Signature)
@@ -47,13 +47,13 @@ reduceTo r sig v f =
 {-# COMPILE AGDA2HS reduceTo #-}
 
 
-inferType : ∀ (Γ : Context α) u → TCM (Σ[ t ∈ Type α ] Γ ⊢ u ∶ t)
+inferType : ∀ (Γ : Context α) u → TCM (Σ[ t ∈ Term α ] Γ ⊢ u ∶ t)
 checkType : ∀ (Γ : Context α) u t (s : Sort α) → TCM (Γ ⊢ u ∶ t)
 
-inferVar : ∀ Γ (@0 x) (p : x ∈ α) → TCM (Σ[ t ∈ Type α ] Γ ⊢ TVar x p ∶ t)
-inferVar g x p = return $ lookupVar g x p , TyTVar p
+inferVar : ∀ Γ (@0 x) (p : x ∈ α) → TCM (Σ[ t ∈ Term α ] Γ ⊢ TVar x p ∶ t)
+inferVar g x p = return $ unType (lookupVar g x p) , TyTVar p
 
-inferApp : ∀ Γ u e → TCM (Σ[ t ∈ Type α ] Γ ⊢ TApp u e ∶ t)
+inferApp : ∀ Γ u e → TCM (Σ[ t ∈ Term α ] Γ ⊢ TApp u e ∶ t)
 inferApp ctx u (Syntax.EArg v) = do
   let r = rezzScope ctx
   fuel      ← tcmFuel
@@ -61,11 +61,11 @@ inferApp ctx u (Syntax.EArg v) = do
 
   tu  , gtu ← inferType ctx u
 
-  (TPi x sa sr at rt) ⟨ rtp ⟩  ← reduceTo r sig tu fuel
+  (TPi x (El sa at) (El sr rt)) ⟨ rtp ⟩  ← reduceTo r sig tu fuel
     where _ → tcError "couldn't reduce term to a pi type"
 
   gtv ← checkType ctx v at sa
-  let sf = funSort sa sr
+  let sf = piSort sa sr
       gc = CRedL {t = TSort sf} rtp CRefl
 
   return $ substTop r v rt , TyAppE gtu (TyArg {k = sf} gc gtv)
@@ -75,59 +75,55 @@ inferApp ctx u (Syntax.ECase bs)  = tcError "not implemented"
 
 inferPi
   : ∀ Γ (@0 x : name)
-  (su sv : Sort α)
-  (u : Term α)
-  (v : Term (x ◃ α))
-  → TCM (Σ[ ty ∈ Type α ] Γ ⊢ TPi x su sv u v ∶ ty)
-inferPi ctx x su sv u v = do
+  (a : Type α)
+  (b : Type (x ◃ α))
+  → TCM (Σ[ ty ∈ Term α ] Γ ⊢ TPi x a b ∶ ty)
+inferPi ctx x (El su u) (El sv v) = do
   tu <- checkType ctx u (TSort su) (sucSort su)
-  let wsv = weakenSort (subWeaken subRefl) sv
-  tv <- checkType (ctx , x ∶ u) v (TSort wsv) (sucSort wsv)
-  pure $ TSort (funSort su sv) , TyPi tu tv
+  tv <- checkType (ctx , x ∶ El su u) v (TSort sv) (sucSort sv)
+  pure $ TSort (piSort su sv) , TyPi tu tv
 
-inferTySort : ∀ Γ (s : Sort α) → TCM (Σ[ ty ∈ Type α ] Γ ⊢ TSort s ∶ ty)
+inferTySort : ∀ Γ (s : Sort α) → TCM (Σ[ ty ∈ Term α ] Γ ⊢ TSort s ∶ ty)
 inferTySort ctx (STyp x) = return $ TSort (STyp $ 1 + x) , TyType
 
-inferDef : ∀ Γ (@0 f : name) (p : f ∈ defScope) → TCM (Σ[ ty ∈ Type α ] Γ ⊢ TDef f p ∶ ty)
+inferDef : ∀ Γ (@0 f : name) (p : f ∈ defScope) → TCM (Σ[ ty ∈ Term α ] Γ ⊢ TDef f p ∶ ty)
 inferDef ctx f p = do
   rezz sig ← tcmSignature
-  pure $ weaken subEmpty (getType sig f p) , TyDef p
+  pure $ weaken subEmpty (unType (getType sig f p)) , TyDef p
 
 checkLambda : ∀ Γ (@0 x : name)
               (u : Term (x ◃ α))
               (ty : Type α)
-              (s : Sort α)
-              → TCM (Γ ⊢ TLam x u ∶ ty)
-checkLambda ctx x u (TPi y su sv tu tv) _ = do
-  d ← checkType (ctx , x ∶ tu) u (renameTop (rezzScope ctx) tv) (weakenSort (subWeaken subRefl) sv)
+              → TCM (Γ ⊢ TLam x u ∶ unType ty)
+checkLambda ctx x u (El _ (TPi y (El su tu) (El sv tv))) = do
+  d ← checkType (ctx , x ∶ El su tu) u (renameTop (rezzScope ctx) tv) {!   !}
   return $ TyLam d
-checkLambda ctx x u ty s = do
+checkLambda ctx x u (El s ty) = do
   let r = rezzScope ctx
   rezz sig ← tcmSignature
   fuel ← tcmFuel
 
-  (TPi y su sv tu tv) ⟨ rtp ⟩ ← reduceTo r sig ty fuel
+  (TPi y (El su tu) (El sv tv)) ⟨ rtp ⟩ ← reduceTo r sig ty fuel
     where _ → tcError "couldn't reduce a term to a pi type"
   let gc = CRedR {t = TSort s} rtp CRefl
 
-  d ← checkType (ctx , x ∶ tu) u (renameTop (rezzScope ctx) tv) (weakenSort (subWeaken subRefl) sv)
+  d ← checkType (ctx , x ∶ El su tu) u (renameTop (rezzScope ctx) tv) {!   !}
   return $ TyConv (TyLam d) gc
 
 checkLet : ∀ Γ (@0 x : name)
            (u : Term α)
            (v : Term (x ◃ α))
            (ty : Type α)
-           (s : Sort α)
-           → TCM (Γ ⊢ TLet x u v ∶ ty)
-checkLet ctx x u v ty s = do
+           → TCM (Γ ⊢ TLet x u v ∶ unType ty)
+checkLet ctx x u v (El s ty) = do
   tu , dtu  ← inferType ctx u
-  dtv       ← checkType (ctx , x ∶ tu) v (weaken (subWeaken subRefl) ty) (weakenSort (subWeaken subRefl) s)
+  dtv       ← checkType (ctx , x ∶ El {!   !} tu) v (weaken (subWeaken subRefl) ty) (weakenSort (subWeaken subRefl) s)
   return $ TyLet {r = rezzScope ctx} dtu dtv
 
 checkCoerce : ∀ Γ (t : Term α)
-            → Σ[ ty ∈ Type α ] Γ ⊢ t ∶ ty
-            → (cty : Type α) -- the type we want to have
-            → (tty : Type α) -- the type of types
+            → Σ[ ty ∈ Term α ] Γ ⊢ t ∶ ty
+            → (cty : Term α) -- the type we want to have
+            → (tty : Term α) -- the type of types
             → TCM (Γ ⊢ t ∶ cty)
 --FIXME: first reduce the type, patmatch on the type
 --the depending on what the type is do either
@@ -149,17 +145,17 @@ checkType ctx (TDef d p) ty s =  do
   tdef ← inferDef ctx d p
   checkCoerce ctx (TDef d p) tdef ty (TSort s)
 checkType ctx (TCon c p x) ty s = tcError "not implemented yet"
-checkType ctx (TLam x te) ty s = checkLambda ctx x te ty s
+checkType ctx (TLam x te) ty s = checkLambda ctx x te (El s ty)
 checkType ctx t@(TApp u e) ty s = do
   tapp ← inferApp ctx u e
   checkCoerce ctx t tapp ty (TSort s)
-checkType ctx t@(TPi x su sv u v) ty s = do
-  tpi ← inferPi ctx x su sv u v
+checkType ctx t@(TPi x (El su u) (El sv v)) ty s = do
+  tpi ← inferPi ctx x (El su u) (El sv v)
   checkCoerce ctx t tpi ty (TSort s)
 checkType ctx t@(TSort s) ty st = do
   tts ← inferTySort ctx s
   checkCoerce ctx t tts ty (TSort s)
-checkType ctx (TLet x u v) ty s = checkLet ctx x u v ty s
+checkType ctx (TLet x u v) ty s = checkLet ctx x u v (El s ty)
 checkType ctx (TAnn u t) ty s = tcError "not implemented yet"
 
 {-# COMPILE AGDA2HS checkType #-}
@@ -169,14 +165,14 @@ inferType ctx (TDef d p) = inferDef ctx d p
 inferType ctx (TCon c p x) = tcError "not implemented yet"
 inferType ctx (TLam x te) = tcError "can't infer the type of a lambda"
 inferType ctx (TApp u e) = inferApp ctx u e
-inferType ctx (TPi x su sv u v) = inferPi ctx x su sv u v
+inferType ctx (TPi x a b) = inferPi ctx x a b
 inferType ctx (TSort s) = inferTySort ctx s
 inferType ctx (TLet x te te₁) = tcError "can't infer the type of a let"
 inferType ctx (TAnn u t) = tcError "not implemented yet"
 
 {-# COMPILE AGDA2HS inferType #-}
 
-inferSort : (Γ : Context α) (t : Type α) → TCM (Σ[ s ∈ Sort α ] Γ ⊢ t ∶ TSort s)
+inferSort : (Γ : Context α) (t : Term α) → TCM (Σ[ s ∈ Sort α ] Γ ⊢ t ∶ TSort s)
 inferSort ctx t = do
   let r = rezzScope ctx
   rezz sig ← tcmSignature


### PR DESCRIPTION
We actually need the sort of a type quite often, so it makes more sense to carry it around bundled with the type itself rather than pass it around as an additional argument. Currently I just did the minimal change to update the syntax, but probably the typing rules and the typechecker could also benefit from passing around the sort of types more explicitly.