### PR TITLE
Ensure coverage and consistent ordering of case branches

### DIFF
--- a/src/Agda/Core/Reduce.agda
+++ b/src/Agda/Core/Reduce.agda
@@ -6,7 +6,7 @@ module Agda.Core.Reduce
   (@0 globals : Globals name)
   where
 
-open import Haskell.Prelude hiding (All; coerce; _,_,_) renaming (_,_ to infixr 5 _,_)
+open import Haskell.Prelude hiding (All; coerce; _,_,_; c) renaming (_,_ to infixr 5 _,_)
 open import Haskell.Extra.Dec
 open import Haskell.Extra.Refinement
 open import Haskell.Extra.Erase
@@ -20,9 +20,9 @@ open import Agda.Core.Utils
 private open module @0 G = Globals globals
 
 private variable
-  @0 x     : name
-  @0 α β γ : Scope name
-  @0 u v w : Term α
+  @0 x c      : name
+  @0 α β γ cs : Scope name
+  @0 u v w    : Term α
 
 data Environment : (@0 α β : Scope name) → Set where
   EnvNil  : Environment α α
@@ -74,11 +74,11 @@ unState r (MkState e v s) = substTerm (envToSubst r e) (applyElims v s)
 
 {-# COMPILE AGDA2HS unState #-}
 
-lookupBranch : Branches α → (@0 c : name) (p : c ∈ conScope)
+lookupBranch : Branches α cs → (@0 c : name) (p : c ∈ conScope)
              → Maybe ( Rezz _ (lookupAll fieldScope p)
                      × Term ((lookupAll fieldScope p) <> α))
-lookupBranch [] c k = Nothing
-lookupBranch (BBranch c' k' aty u ∷ bs) c p =
+lookupBranch BsNil c k = Nothing
+lookupBranch (BsCons (BBranch c' k' aty u) bs) c p =
   case decIn k' p of λ where
     (True  ⟨ refl ⟩) → Just (aty , u)
     (False ⟨ _    ⟩) → lookupBranch bs c p

--- a/src/Agda/Core/Substitute.agda
+++ b/src/Agda/Core/Substitute.agda
@@ -6,7 +6,7 @@ module Agda.Core.Substitute
   (@0 globals : Globals name)
   where
 
-open import Haskell.Prelude hiding (All)
+open import Haskell.Prelude hiding (All; c)
 open import Haskell.Extra.Dec
 open import Haskell.Extra.Erase
 
@@ -16,16 +16,16 @@ open import Agda.Core.Syntax globals
 open import Agda.Core.Signature globals
 
 private variable
-  @0 x     : name
-  @0 α β γ : Scope name
+  @0 x c     : name
+  @0 α β γ cs : Scope name
 
 substTerm     : α ⇒ β → Term α → Term β
 substSort     : α ⇒ β → Sort α → Sort β
 substType     : α ⇒ β → Type α → Type β
 substElim     : α ⇒ β → Elim α → Elim β
 substElims    : α ⇒ β → Elims α → Elims β
-substBranch   : α ⇒ β → Branch α → Branch β
-substBranches : α ⇒ β → Branches α → Branches β
+substBranch   : α ⇒ β → Branch α c → Branch β c
+substBranches : α ⇒ β → Branches α cs → Branches β cs
 substSubst    : α ⇒ β → γ ⇒ α → γ ⇒ β
 
 substSort f (STyp x) = STyp x
@@ -56,8 +56,8 @@ substElims f = map (substElim f)
 substBranch f (BBranch c k aty u) = BBranch c k aty (substTerm (liftSubst aty f) u)
 {-# COMPILE AGDA2HS substBranch #-}
 
-substBranches f [] = []
-substBranches f (b ∷ bs) = substBranch f b ∷ substBranches f bs
+substBranches f BsNil = BsNil
+substBranches f (BsCons b bs) = BsCons (substBranch f b) (substBranches f bs)
 {-# COMPILE AGDA2HS substBranches #-}
 
 substSubst f SNil = SNil

--- a/src/Agda/Core/TestReduce.agda
+++ b/src/Agda/Core/TestReduce.agda
@@ -74,7 +74,9 @@ module Tests (@0 x y z : name) where
     test₁ = refl
 
     testTerm₂ : Term α
-    testTerm₂ = TApp `true (ECase (BBranch "true" inHere (rezz _) `false ∷ BBranch "false" (inThere inHere) (rezz _) `true ∷ []))
+    testTerm₂ = TApp `true (ECase (BsCons (BBranch "true" inHere (rezz _) `false) 
+                                  (BsCons (BBranch "false" (inThere inHere) (rezz _) `true)
+                                   BsNil)))
 
     @0 testProp₂ : Set
     testProp₂ = reduceClosed sig testTerm₂ fuel ≡ Just `false


### PR DESCRIPTION
This is not yet complete, but should serve as a discussion on a possible way to ensure that the branches in a case statement cover all constructors and always follow the same ordering. The neatest way I found to do this (i.e. the one requiring no proving) is to index the syntax `Branch` and `Branches` with the name / scope for the constructors respectively.