### PR TITLE
Minimize unfolding

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
     "scope-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1707234991,
-        "narHash": "sha256-WSXV36DMoapHF71jXyh4hrOiFJMuTJ1pEc/nQNyzZJE=",
+        "lastModified": 1707494419,
+        "narHash": "sha256-vnE4nbJQ6BQ9pZc5+ftNOFx62CLGfp0VyhzDN011pmI=",
         "owner": "jespercockx",
         "repo": "scope",
-        "rev": "95d9a236e18df6e101fd058c4a229bcff1f2a3ab",
+        "rev": "ce0a028e72f106661707904c872330b4b72e5933",
         "type": "github"
       },
       "original": {

--- a/src/Agda/Core/Converter.agda
+++ b/src/Agda/Core/Converter.agda
@@ -205,14 +205,14 @@ convertElims ctx t u (EArg w) (EArg w') = do
 convertElims ctx s u w w' = tcError "not implemented yet"
 
 convertSubsts ctx tel SNil p = return CSNil
-convertSubsts ctx tel (SCons x st) p =
-  caseSubstBind (λ ss → TCM (ctx ⊢ (SCons x st) ⇔ ss)) p $ λ y pt →
-  caseTelBind _ tel $ λ a tel → do
-    let r = rezzScope ctx
-    hc ← convertCheck ctx (unType a) x y
-    tc ← convertSubsts ctx (substTelescope (SCons x (idSubst r)) tel) st pt
-    return $ CSCons hc tc
-
+convertSubsts ctx tel (SCons x st) p = 
+  caseSubstBind p λ where
+    y pt {{refl}} → caseTelBind tel λ a rest → do
+      let r = rezzScope ctx
+      hc ← convertCheck ctx (unType a) x y
+      tc ← convertSubsts ctx (substTelescope (SCons x (idSubst r)) rest) st pt
+      return (CSCons hc tc)
+    
 convertCheck ctx ty t q = do
   let r = rezzScope ctx
   fuel      ← tcmFuel

--- a/src/Agda/Core/Signature.agda
+++ b/src/Agda/Core/Signature.agda
@@ -15,6 +15,7 @@ open import Agda.Core.Syntax globals
 private open module @0 G = Globals globals
 
 private variable
+  @0 x : name
   @0 α β γ : Scope name
 
 {- Telescopes are like contexts, mapping variables to types.
@@ -28,12 +29,12 @@ data Telescope (@0 α : Scope name) : @0 Scope name → Set where
 
 opaque
   unfolding Scope
-  caseTelBind : {@0 x : name}
-                (P : @0 Telescope α (x ◃ β) → Set)
-                (tel : Telescope α (x ◃ β))
-              → ((a : Type α) (tel : Telescope (x ◃ α) β) → P (ExtendTel x a tel))
-              → P tel
-  caseTelBind P (ExtendTel _ a tel) f = f a tel
+  caseTelBind : (tel : Telescope α (x ◃ β))
+              → ((a : Type α) (rest : Telescope (x ◃ α) β) → @0 {{tel ≡ ExtendTel x a rest}} → d)
+              → d
+  caseTelBind (ExtendTel _ a tel) f = f a tel
+
+{-# COMPILE AGDA2HS caseTelBind #-}
 
 record Constructor (@0 pars : Scope name) (@0 ixs : Scope name) (@0 c : name) (@0 cp  : c ∈ conScope) : Set where
   field

--- a/src/Agda/Core/Syntax.agda
+++ b/src/Agda/Core/Syntax.agda
@@ -169,14 +169,17 @@ lookupSubst : α ⇒ β
 lookupSubst SNil x q = inEmptyCase q
 lookupSubst (SCons u f) x q = inBindCase q (λ _ → u) (lookupSubst f x)
 
+{-# COMPILE AGDA2HS lookupSubst #-}
+
 opaque
   unfolding Scope
-  caseSubstBind : (P : @0 Subst (bind x α) β → Set) → (s : Subst (bind x α) β)
-                → ((t : Term β) → (s : Subst α β) → P (SCons t s))
-                → P s
-  caseSubstBind P (SCons x s) f = f x s
 
-{-# COMPILE AGDA2HS lookupSubst #-}
+  caseSubstBind : (s : Subst (bind x α) β)
+                → ((t : Term β) → (s' : Subst α β) → @0 {{s ≡ SCons t s'}} → d)
+                → d
+  caseSubstBind (SCons x s) f = f x s
+
+  {-# COMPILE AGDA2HS caseSubstBind #-}
 
 weaken         : α ⊆ β → Term α → Term β
 weakenSort     : α ⊆ β → Sort α → Sort β

--- a/src/Agda/Core/Syntax.agda
+++ b/src/Agda/Core/Syntax.agda
@@ -295,11 +295,11 @@ opaque
   revIdSubst {α} r = subst0 (λ s →  s ⇒ (~ α)) (revsInvolution α) (revSubst (idSubst (rezzCong revScope r)))
 
 raise : {@0 α β : Scope name} → Rezz _ α → Term β → Term (α <> β)
-raise r = weaken (subRight (splitRefl r))
+raise r = weaken (subJoinDrop r subRefl)
 {-# COMPILE AGDA2HS raise #-}
 
 raiseType : {@0 α β : Scope name} → Rezz _ α → Type β → Type (α <> β)
-raiseType r = weakenType (subRight (splitRefl r))
+raiseType r = weakenType (subJoinDrop r subRefl)
 {-# COMPILE AGDA2HS raiseType #-}
 
 strengthen : α ⊆ β → Term β → Maybe (Term α)

--- a/src/Agda/Core/TestReduce.agda
+++ b/src/Agda/Core/TestReduce.agda
@@ -47,22 +47,22 @@ sig = allEmpty
 
 open import Agda.Core.Reduce globals
 
+{-# TERMINATING #-}
+fuel : Fuel
+fuel = More fuel
+
 opaque
-  unfolding lookupAll inHere inThere splitRefl splitJoinRight subBindDrop subLeft
+  unfolding ScopeThings
 
   `true : Term α
   `true = TCon "true" (inHere) SNil
   `false : Term α
   `false = TCon "false" (inThere inHere) SNil
 
-{-# TERMINATING #-}
-fuel : Fuel
-fuel = More fuel
-
 module Tests (@0 x y z : name) where
 
   opaque
-    unfolding step inBindCase inSplitCase inJoinCase `true `false decIn ∅-⋈-injective
+    unfolding ScopeThings `true `false
 
     testTerm₁ : Term α
     testTerm₁ = apply (TLam x (TVar x inHere)) (TSort (STyp 0))

--- a/src/Agda/Core/Typing.agda
+++ b/src/Agda/Core/Typing.agda
@@ -125,7 +125,7 @@ data TyTerm {α} Γ where
   TyAnn
     : Γ ⊢ u ∶ a
     ------------------
-    → Γ ⊢ TAnn u a ∶ sortType (typeSort a)
+    → Γ ⊢ TAnn u a ∶ a
 
   TyConv
     : Γ ⊢ u ∶ a

--- a/src/Agda/Core/Typing.agda
+++ b/src/Agda/Core/Typing.agda
@@ -169,7 +169,7 @@ data TyBranch {α} Γ dt ps rt where
               {@0 rα : Rezz _ α}
               (rhs : Term (~ lookupAll fieldScope c∈cons <> α))
               (let ctel = substTelescope ps (conTelescope con)
-                   cargs = weakenSubst (subLeft (splitRefl (rezzCong revScope r)))
+                   cargs = weakenSubst (subJoinHere (rezzCong revScope r) subRefl)
                                        (revIdSubst r)
                    idsubst = weakenSubst (subJoinDrop (rezzCong revScope r) subRefl)
                                          (idSubst rα)


### PR DESCRIPTION
While writing on our scope representation, I noticed that we actually do more unfolding than really needed. This is my stab at reducing its use as much as possible. I could reduce it further but that would require exposing proofs that the empty scope and `bind` are injective and disjoint, and doing unification manually.