### PR TITLE
Constructor & case type-checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean-lib:
 	rm -rf lib
 
 clean-agdai:
-	rm -f src/*.agdai
+	rm -rf src/*.agdai _build
 
 app: alllib
 	cabal build

--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713204077,
-        "narHash": "sha256-NuvemB8DZspj1njQ8pQ0wO3GHVkbvpR77M0ZI9aZrbI=",
+        "lastModified": 1713349448,
+        "narHash": "sha256-mJtBYsjveRMqGHBMeKfqr1NrFo0iLVT51jWOEh89tHE=",
         "owner": "jespercockx",
         "repo": "scope",
-        "rev": "c03cb688dc7579d81a138cfffed5340b43dc5e91",
+        "rev": "48dc91d8db5b70850d79f96a6412c62a4377302d",
         "type": "github"
       },
       "original": {

--- a/rewrite-rules.yml
+++ b/rewrite-rules.yml
@@ -1,0 +1,5 @@
+rewrites:
+
+  - from: "Haskell.Prim.Tuple.first"
+    to: "first"
+    importing: "Data.Bifunctor"

--- a/src/Agda/Core/Conversion.agda
+++ b/src/Agda/Core/Conversion.agda
@@ -117,8 +117,8 @@ data ConvBranch {α} Γ where
 data ConvSubst {α} Γ where
   CSNil : ConvSubst Γ {β = mempty} us vs
   CSCons : {@0 x : name} 
-         → Conv Γ u v
-         → ConvSubst Γ us vs
-         → ConvSubst Γ (SCons {x = x} u us) (SCons {x = x} v vs)
+         → Γ ⊢ u ≅ v
+         → Γ ⊢ us ⇔ vs
+         → Γ ⊢ (SCons {x = x} u us) ⇔ (SCons {x = x} v vs)
 
 {-# COMPILE AGDA2HS ConvSubst #-}

--- a/src/Agda/Core/Conversion.agda
+++ b/src/Agda/Core/Conversion.agda
@@ -41,7 +41,10 @@ data ConvSubst (@0 Γ : Context α) : @0 β ⇒ α → @0 β ⇒ α → Set
 
 data ConvBranches (@0 Γ : Context α) : @0 Branches α cs → @0 Branches α cs → Set where
   CBranchesNil : {bs bp : Branches α mempty} → ConvBranches Γ bs bp
-  CBranchesCons : {b1 b2 : Branch α cn} {bs1 bs2 : Branches α cs} → ConvBranch Γ b1 b2 → ConvBranches Γ bs1 bs2 → ConvBranches Γ (BsCons b1 bs1) (BsCons b2 bs2)
+  CBranchesCons : {b1 b2 : Branch α cn} {bs1 bs2 : Branches α cs}
+                → ConvBranch Γ b1 b2
+                → ConvBranches Γ bs1 bs2
+                → ConvBranches Γ (BsCons b1 bs1) (BsCons b2 bs2)
 
 
 {-# COMPILE AGDA2HS Conv     #-}
@@ -92,9 +95,7 @@ data Conv {α} Γ where
          → Γ ⊢ u  ≅ v
   CRedR  : @0 ReducesTo sig v v'
          → Γ ⊢ u  ≅ v'
-         → Γ ⊢ u  ≅ v 
-
-{-# COMPILE AGDA2HS Conv #-}
+         → Γ ⊢ u  ≅ v
 
 data ConvElim {α} Γ where
   CEArg  : Γ ⊢ v ≅ v'
@@ -116,7 +117,6 @@ data ConvBranch {α} Γ where
            → (addContextTel tel Γ) ⊢ t1 ≅ t2
            → ConvBranch Γ (BBranch c cp r1 t1) (BBranch c cp r2 t2)
 
-{-# COMPILE AGDA2HS ConvElim #-}
 
 data ConvSubst {α} Γ where
   CSNil : ConvSubst Γ {β = mempty} us vs
@@ -124,5 +124,3 @@ data ConvSubst {α} Γ where
          → Γ ⊢ u ≅ v
          → Γ ⊢ us ⇔ vs
          → Γ ⊢ (SCons {x = x} u us) ⇔ (SCons {x = x} v vs)
-
-{-# COMPILE AGDA2HS ConvSubst #-}

--- a/src/Agda/Core/Conversion.agda
+++ b/src/Agda/Core/Conversion.agda
@@ -99,9 +99,13 @@ data Conv {α} Γ where
 data ConvElim {α} Γ where
   CEArg  : Γ ⊢ v ≅ v'
          → Γ ⊢ EArg v ≃ EArg v'
-  CECase : (bs bp : Branches α cs)
+  CECase : {@0 r : Rezz _ α}
+           (bs bp : Branches α cs)
+           (ms : Type (x ◃ α)) (mp : Type (y ◃ α))
+         --TODO: enforce that a is the type of the scrutinee
+         → Γ , x ∶ a ⊢ renameTop r (unType ms) ≅ renameTop r (unType mp)
          → ConvBranches Γ bs bp
-         → Γ ⊢ ECase bs ≃ ECase bp
+         → Γ ⊢ ECase bs ms ≃ ECase bp mp
   -- TODO: CEProj : {!   !}
 
 data ConvBranch {α} Γ where

--- a/src/Agda/Core/Conversion.agda
+++ b/src/Agda/Core/Conversion.agda
@@ -40,7 +40,7 @@ data ConvBranch (@0 Γ : Context α) : @0 Branch α cn → @0 Branch α cn → S
 data ConvSubst (@0 Γ : Context α) : @0 β ⇒ α → @0 β ⇒ α → Set
 
 data ConvBranches (@0 Γ : Context α) : @0 Branches α cs → @0 Branches α cs → Set where
-  CBranchesNil : ConvBranches Γ BsNil BsNil
+  CBranchesNil : {bs bp : Branches α mempty} → ConvBranches Γ bs bp
   CBranchesCons : {b1 b2 : Branch α cn} {bs1 bs2 : Branches α cs} → ConvBranch Γ b1 b2 → ConvBranches Γ bs1 bs2 → ConvBranches Γ (BsCons b1 bs1) (BsCons b2 bs2)
 
 

--- a/src/Agda/Core/Converter.agda
+++ b/src/Agda/Core/Converter.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --allow-unsolved-metas #-}
 open import Haskell.Prelude
 
 open import Scope
@@ -234,10 +233,10 @@ convertElims fl ctx t           u (EArg w) (EArg w') = do
   let ksort = piSort (typeSort a) (typeSort b)
   cw ← convertCheck fl ctx (unType a) w w'
   return $ substTop r w (unType b) Σ, CEArg cw
-convertElims fl ctx t u (ECase ws m) (ECase ws' m') = do
+convertElims fl ctx tu u (ECase ws m) (ECase ws' m') = do
   let r = rezzScope ctx
   rezz sig  ← tcmSignature
-  (TDef d dp , els) ⟨ rp ⟩  ← reduceElimView _ _ <$> reduceTo r sig t fl
+  (TDef d dp , els) ⟨ rp ⟩  ← reduceElimView _ _ <$> reduceTo r sig tu fl
     where
       _ → tcError "can't typecheck a constrctor with a type that isn't a def application"
   (DatatypeDef df) ⟨ dep ⟩ ← return $ witheq (getDefinition sig d dp)
@@ -250,7 +249,7 @@ convertElims fl ctx t u (ECase ws m) (ECase ws' m') = do
   (Erased refl) ← liftMaybe
     (allInScope {γ = conScope} (allBranches ws) (allBranches ws'))
     "couldn't verify that branches cover the same constructors"
-  cm ← convertCheck fl (ctx , _ ∶ El {!!} t)
+  cm ← convertCheck fl (ctx , _ ∶ El (substSort psubst $ dataSort df) tu)
                        (TSort (typeSort m))
                        (renameTop r (unType m))
                        (renameTop r (unType m'))

--- a/src/Agda/Core/Converter.agda
+++ b/src/Agda/Core/Converter.agda
@@ -143,7 +143,7 @@ convCons {α = α} (More fl) ctx s f g p q lp lq = do
       let (_ Σ, con) = lookupAll (dataConstructors df) cdi
       params ← liftMaybe (traverse maybeArg els)
         "not all arguments to the datatype are terms"
-      psubst ← liftMaybe (listSubst (rezzTel (dataParameterTel df)) params)
+      (psubst , _) ← liftMaybe (listSubst (rezzTel (dataParameterTel df)) params)
         "couldn't construct a substitution for parameters"
       let ctel = substTelescope psubst (conTelescope con)
       csp ← convertSubsts fl ctx ctel lp lq

--- a/src/Agda/Core/Converter.agda
+++ b/src/Agda/Core/Converter.agda
@@ -234,9 +234,7 @@ convertElims fl ctx t           u (EArg w) (EArg w') = do
   let ksort = piSort (typeSort a) (typeSort b)
   cw ← convertCheck fl ctx (unType a) w w'
   return $ substTop r w (unType b) Σ, CEArg cw
-convertElims fl ctx t u (ECase ws) (ECase ws') = do
-  let rt : Term ({!!} ◃ α)
-      rt = {!!}
+convertElims fl ctx t u (ECase ws m) (ECase ws' m') = do
   let r = rezzScope ctx
   rezz sig  ← tcmSignature
   (TDef d dp , els) ⟨ rp ⟩  ← reduceElimView _ _ <$> reduceTo r sig t fl
@@ -252,8 +250,12 @@ convertElims fl ctx t u (ECase ws) (ECase ws') = do
   (Erased refl) ← liftMaybe
     (allInScope {γ = conScope} (allBranches ws) (allBranches ws'))
     "couldn't verify that branches cover the same constructors"
-  cbs ← convertBranches fl ctx df psubst rt ws ws'
-  return (substTop r u rt Σ, CECase ws ws' cbs)
+  cm ← convertCheck fl (ctx , _ ∶ El {!!} t)
+                       (TSort (typeSort m))
+                       (renameTop r (unType m))
+                       (renameTop r (unType m'))
+  cbs ← convertBranches fl ctx df psubst (unType m) ws ws'
+  return (substTop r u (unType m) Σ, CECase ws ws' m m' cm cbs)
 convertElims fl ctx s u (EProj _ _) (EProj _ _) = tcError "not implemented yet"
 convertElims fl ctx s u _           _ = tcError "two elims aren't the same shape"
 

--- a/src/Agda/Core/Converter.agda
+++ b/src/Agda/Core/Converter.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --allow-unsolved-metas #-}
 open import Haskell.Prelude
 
 open import Scope
@@ -137,8 +138,9 @@ convCons {α = α} (More fl) ctx s f g p q lp lq = do
       (DatatypeDef df) ← return $ getDefinition sig d dp
         where
           _ → tcError "can't convert two constructors when their type isn't a datatype"
-      con ← liftMaybe (getConstructor f p df)
+      cdi ⟨ refl ⟩ ← liftMaybe (getConstructor f p df)
         "can't find a constructor with such a name"
+      let (_ Σ, con) = lookupAll (dataConstructors df) cdi
       params ← liftMaybe (traverse maybeArg els)
         "not all arguments to the datatype are terms"
       psubst ← liftMaybe (listSubst (rezzTel (dataParameterTel df)) params)

--- a/src/Agda/Core/Converter.agda
+++ b/src/Agda/Core/Converter.agda
@@ -103,23 +103,23 @@ convSortsI ctx (STyp u) (STyp u') =
 
 convertCheck : Fuel → ∀ Γ (ty : Term α) (t q : Term α) → TCM (Γ ⊢ t ≅ q)
 convertInfer : Fuel → ∀ Γ (t q : Term α) → TCM (Σ (Term α) (λ ty → Γ ⊢ t ≅ q))
-convertElims : Fuel
-             → ∀ Γ
-                (s : Term α)
-                (u : Term α)
-                (v v' : Elim α)
-             → TCM (Σ (Term α) (λ f → Γ ⊢ v ≃ v'))
-convertSubsts : Fuel
-              → ∀ {@0 α β} Γ
-                  (ty : Telescope α β)
-                  (s p : β ⇒ α)
+convertElims : Fuel →
+             ∀ Γ
+               (tu   : Term α)
+               (u    : Term α)
+               (v v' : Elim α)
+             → TCM (Σ (Term α) (λ _ → Γ ⊢ v ≃ v'))
+convertSubsts : Fuel →
+              ∀ {@0 α β} Γ
+                (ty : Telescope α β)
+                (s p : β ⇒ α)
               → TCM (Γ ⊢ s ⇔ p)
-convertBranches : Fuel
-                → ∀ {@0 x : name} {@0 cons : Scope name} Γ
-                    (dt : Datatype)
-                    (ps : dataParameterScope dt ⇒ α)
-                    (rty : Term (x ◃ α))
-                    (bs bp : Branches α cons)
+convertBranches : Fuel →
+                ∀ {@0 x : name} {@0 cons : Scope name} Γ
+                  (dt : Datatype)
+                  (ps : dataParameterScope dt ⇒ α)
+                  (rty : Term (x ◃ α))
+                  (bs bp : Branches α cons)
                 → TCM (ConvBranches Γ bs bp)
 
 convCons : Fuel →

--- a/src/Agda/Core/Converter.agda
+++ b/src/Agda/Core/Converter.agda
@@ -129,11 +129,7 @@ convCons {α = α} (More fl) ctx s f g p q lp lq = do
   let r = rezzScope ctx
   fuel      ← tcmFuel
   rezz sig  ← tcmSignature
-  let
-    mapElimView : ∃ (Term α) (ReducesTo _ _)
-                → ∃[ (t , els) ∈ Term α × Elims α ] ReducesTo _ _ (applyElims t els)
-    mapElimView = λ where (v ⟨ p ⟩) → (elimView v) ⟨ subst0 (λ t → ReducesTo _ s t) (sym $ applyElimView v) p ⟩
-  (TDef d dp , els) ⟨ rp ⟩  ← mapElimView <$> reduceTo r sig s fuel
+  (TDef d dp , els) ⟨ rp ⟩  ← reduceElimView sig s <$> reduceTo r sig s fuel
     where
       _ → tcError "can't convert two constructors when their type isn't a definition"
   ifDec (decIn p q)

--- a/src/Agda/Core/Reduce.agda
+++ b/src/Agda/Core/Reduce.agda
@@ -132,7 +132,7 @@ step sig (MkState e (TLet x v w) s) =
 step sig (MkState e (TDef d q) s) = case getBody sig d q of λ where
   (Just v) → Just (MkState e (weaken subEmpty v) s)
   Nothing  → Nothing
-step sig (MkState e (TCon c q vs) (ECase bs ∷ s)) =
+step sig (MkState e (TCon c q vs) (ECase bs _ ∷ s)) =
   case lookupBranch bs c q of λ where
     (Just (r , v)) → Just (MkState
       (extendEnvironment (revSubst vs) e)

--- a/src/Agda/Core/Reduce.agda
+++ b/src/Agda/Core/Reduce.agda
@@ -170,3 +170,11 @@ reduceClosed = reduce (rezz _)
 
 ReducesTo : (sig : Signature) (v w : Term α) → Set
 ReducesTo {α = α} sig v w = Σ0[ r ∈ Rezz _ α ] ∃[ f ∈ Fuel ] reduce r sig v f ≡ Just w
+
+reduceElimView : ∀ sig (s : Term α)
+               → ∃[ t ∈ Term α ]                   ReducesTo sig s t
+               → ∃[ (t , els) ∈ Term α × Elims α ] ReducesTo sig s (applyElims t els)
+reduceElimView sig s (v ⟨ p ⟩) =
+  (elimView v) ⟨ subst0 (λ t → ReducesTo sig s t) (sym $ applyElimView v) p ⟩
+
+{-# COMPILE AGDA2HS reduceElimView #-}

--- a/src/Agda/Core/Signature.agda
+++ b/src/Agda/Core/Signature.agda
@@ -95,21 +95,24 @@ getBody sig x p = case getDefinition sig x p of λ where
 {-# COMPILE AGDA2HS getBody #-}
 
 getConstructor : (@0 c : name) (cp : c ∈ conScope) (d : Datatype)
-               → Maybe (Constructor (dataParameterScope d) (dataIndexScope d) c cp)
-getConstructor c cp d =
-  findAll (allIn $ dataConstructors d) dec
+               → Maybe (∃[ cd ∈ (c ∈ dataConstructorScope d) ]
+                         fst (lookupAll (dataConstructors d) cd) ≡ cp)
+getConstructor c cp d = findAll (allLookup (dataConstructors d)) dec
   where
     -- can't have a lambda take two arguments for agda2hs, so here's a local def
     dec : {@0 el : name}
-        → Σ (el ∈ conScope)
-            (Constructor (dataParameterScope d) (dataIndexScope d) el)
-            × In el (dataConstructorScope d)
-        → el ∈ (dataConstructorScope d)
-        → Maybe (Constructor (dataParameterScope d) (dataIndexScope d) c cp)
-    dec (cpn Σ, con , _) ret = ifDec (decIn cp cpn) (λ where {{refl}} → Just con) Nothing
+        → ∃ (el ∈ (dataConstructorScope d) × _)
+            (λ where (i , pi) → lookupAll (dataConstructors d) i ≡ pi)
+        → _
+        → Maybe (∃[ cd ∈ (c ∈ dataConstructorScope d) ]
+                  fst (lookupAll (dataConstructors d) cd) ≡ cp)
+    dec ((i , (ci Σ, con)) ⟨ ep ⟩) _ =
+      ifDec (decIn cp ci)
+            (λ where
+              {{refl}} → Just (i ⟨ subst0 (λ (cci Σ, ccon) → fst (lookupAll (dataConstructors d) i) ≡ cci) ep refl ⟩))
+            Nothing
 
 {-# COMPILE AGDA2HS getConstructor #-}
-
 
 weakenTel : α ⊆ γ → Telescope α β → Telescope γ β
 weakenTel p EmptyTel = EmptyTel

--- a/src/Agda/Core/Signature.agda
+++ b/src/Agda/Core/Signature.agda
@@ -94,7 +94,8 @@ getBody sig x p = case getDefinition sig x p of λ where
 
 {-# COMPILE AGDA2HS getBody #-}
 
-getConstructor : (@0 c : name) (cp : c ∈ conScope) (d : Datatype) → Maybe (Constructor (dataParameterScope d) (dataIndexScope d) c cp)
+getConstructor : (@0 c : name) (cp : c ∈ conScope) (d : Datatype)
+               → Maybe (Constructor (dataParameterScope d) (dataIndexScope d) c cp)
 getConstructor c cp d =
   findAll (allIn $ dataConstructors d) dec
   where

--- a/src/Agda/Core/Signature.agda
+++ b/src/Agda/Core/Signature.agda
@@ -29,10 +29,17 @@ data Telescope (@0 α : Scope name) : @0 Scope name → Set where
 
 opaque
   unfolding Scope
+
+  caseTelEmpty : (tel : Telescope α mempty)
+               → (@0 {{tel ≡ EmptyTel}} → d)
+               → d
+  caseTelEmpty EmptyTel f = f
+
   caseTelBind : (tel : Telescope α (x ◃ β))
               → ((a : Type α) (rest : Telescope (x ◃ α) β) → @0 {{tel ≡ ExtendTel x a rest}} → d)
               → d
   caseTelBind (ExtendTel _ a tel) f = f a tel
+
 
 {-# COMPILE AGDA2HS caseTelBind #-}
 

--- a/src/Agda/Core/Substitute.agda
+++ b/src/Agda/Core/Substitute.agda
@@ -45,9 +45,10 @@ substTerm f (TLet x u v)      = TLet x (substTerm f u) (substTerm (liftBindSubst
 substTerm f (TAnn u t)        = TAnn (substTerm f u) (substType f t)
 {-# COMPILE AGDA2HS substTerm #-}
 
-substElim f (EArg u)    = EArg (substTerm f u)
-substElim f (EProj p k) = EProj p k
-substElim f (ECase bs)  = ECase (substBranches f bs)
+substElim f (EArg u)             = EArg (substTerm f u)
+substElim f (EProj p k)          = EProj p k
+substElim f (ECase {x = x} bs m) = ECase (substBranches f bs)
+                                         (substType (liftBindSubst {y = x} f) m)
 {-# COMPILE AGDA2HS substElim #-}
 
 substElims f = map (substElim f)

--- a/src/Agda/Core/Syntax.agda
+++ b/src/Agda/Core/Syntax.agda
@@ -91,7 +91,7 @@ sortType s = El (sucSort s) (TSort s)
 data Elim α where
   EArg  : Term α → Elim α
   EProj : (@0 x : name) → x ∈ defScope → Elim α
-  ECase : (bs : Branches α cs) → Elim α
+  ECase : (bs : Branches α cs) (m : Type (x ◃ α)) → Elim α
   -- TODO: do we need a type annotation for the return type of case?
 {-# COMPILE AGDA2HS Elim deriving Show #-}
 
@@ -230,7 +230,7 @@ weakenType p (El st t) = El (weakenSort p st) (weaken p t)
 
 weakenElim p (EArg x)    = EArg (weaken p x)
 weakenElim p (EProj x k) = EProj x k
-weakenElim p (ECase bs)  = ECase (weakenBranches p bs)
+weakenElim p (ECase bs m)  = ECase (weakenBranches p bs) (weakenType (subBindKeep p) m)
 {-# COMPILE AGDA2HS weakenElim #-}
 
 weakenElims p = map (weakenElim p)
@@ -348,7 +348,7 @@ strengthenType p (El st t) = El <$> strengthenSort p st <*> strengthen p t
 
 strengthenElim p (EArg v) = EArg <$> strengthen p v
 strengthenElim p (EProj f q) = Just (EProj f q)
-strengthenElim p (ECase bs) = ECase <$> strengthenBranches p bs
+strengthenElim p (ECase bs m) = ECase <$> strengthenBranches p bs <*> strengthenType (subBindKeep p) m
 
 strengthenElims p = traverse (strengthenElim p)
 

--- a/src/Agda/Core/Syntax.agda
+++ b/src/Agda/Core/Syntax.agda
@@ -12,6 +12,7 @@ open import Haskell.Prelude hiding (All; coerce; a; b; c)
 open import Haskell.Law.Equality using (sym; subst0)
 open import Haskell.Law.Monoid.Def using (leftIdentity; rightIdentity)
 open import Haskell.Law.Semigroup.Def using (associativity)
+open import Haskell.Prim.Tuple using (first)
 open import Haskell.Extra.Erase
 
 -- NOTE(flupe): comes from scope library, should be moved upstream probably
@@ -250,15 +251,15 @@ dropSubst : {@0 α β : Scope name} {@0 x : name} → (x ◃ α) ⇒ β → α �
 dropSubst f = caseSubstBind f (λ _ g → g)
 {-# COMPILE AGDA2HS dropSubst #-}
 
-listSubst : {@0 β : Scope name} → Rezz _ β → List (Term α) → Maybe (β ⇒ α)
+listSubst : {@0 β : Scope name} → Rezz _ β → List (Term α) → Maybe ((β ⇒ α) × (List (Term α)))
 listSubst (rezz β) [] = 
   caseScope β 
-    (λ where {{refl}} → Just SNil) 
+    (λ where {{refl}} → Just (SNil , []))
     (λ _ _ → Nothing)
 listSubst (rezz β) (v ∷ vs) = 
   caseScope β 
-    (λ where {{refl}} → Just SNil) 
-    (λ where x γ {{refl}} → SCons v <$> listSubst (rezzUnbind (rezz β)) vs)
+    (λ where {{refl}} → Just (SNil , v ∷ vs))
+    (λ where x γ {{refl}} → first (SCons v) <$> listSubst (rezzUnbind (rezz β)) vs)
 {-# COMPILE AGDA2HS listSubst #-}
 
 concatSubst : α ⇒ γ → β ⇒ γ → (α <> β) ⇒ γ

--- a/src/Agda/Core/Syntax.agda
+++ b/src/Agda/Core/Syntax.agda
@@ -92,7 +92,6 @@ data Elim α where
   EArg  : Term α → Elim α
   EProj : (@0 x : name) → x ∈ defScope → Elim α
   ECase : (bs : Branches α cs) (m : Type (x ◃ α)) → Elim α
-  -- TODO: do we need a type annotation for the return type of case?
 {-# COMPILE AGDA2HS Elim deriving Show #-}
 
 Elims α = List (Elim α)

--- a/src/Agda/Core/Syntax.agda
+++ b/src/Agda/Core/Syntax.agda
@@ -108,6 +108,25 @@ data Branches α where
   BsCons : Branch α c → Branches α cs → Branches α (c ◃ cs)
 {-# COMPILE AGDA2HS Branches #-}
 
+opaque
+  unfolding Scope
+
+  caseBsNil : (bs : Branches α mempty)
+            → (@0 {{bs ≡ BsNil}} → d)
+            → d
+  caseBsNil BsNil f = f
+  {-# COMPILE AGDA2HS caseBsNil #-}
+
+  caseBsCons : (bs : Branches α (c ◃ cs))
+             → ((bh : Branch α c) (bt : Branches α cs) → @0 {{bs ≡ BsCons bh bt}} → d)
+             → d
+  caseBsCons (BsCons bh bt) f = f bh bt
+  {-# COMPILE AGDA2HS caseBsCons #-}
+
+rezzBranches : Branches α β → Rezz _ β
+rezzBranches BsNil = rezz mempty
+rezzBranches (BsCons {c = c} bh bt) = rezzCong (λ cs → c ◃ cs) (rezzBranches bt)
+
 apply : Term α → Term α → Term α
 apply u v = TApp u (EArg v)
 {-# COMPILE AGDA2HS apply #-}

--- a/src/Agda/Core/Syntax.agda
+++ b/src/Agda/Core/Syntax.agda
@@ -127,6 +127,10 @@ rezzBranches : Branches α β → Rezz _ β
 rezzBranches BsNil = rezz mempty
 rezzBranches (BsCons {c = c} bh bt) = rezzCong (λ cs → c ◃ cs) (rezzBranches bt)
 
+allBranches : Branches α β → All (λ c → c ∈ conScope) β
+allBranches BsNil = allEmpty
+allBranches (BsCons (BBranch _ ci _ _) bs) = allJoin (allSingl ci) (allBranches bs)
+
 apply : Term α → Term α → Term α
 apply u v = TApp u (EArg v)
 {-# COMPILE AGDA2HS apply #-}

--- a/src/Agda/Core/TCM.agda
+++ b/src/Agda/Core/TCM.agda
@@ -50,6 +50,11 @@ tcError : TCError -> TCM a
 tcError = MkTCM ∘ const ∘ Left
 {-# COMPILE AGDA2HS tcError #-}
 
+assert : Bool → TCError → TCM ⊤
+assert False e = tcError e
+assert True e = MkTCM (const (Right tt))
+{-# COMPILE AGDA2HS assert #-}
+
 liftEither : Either TCError a → TCM a
 liftEither (Left e) = MkTCM λ f → Left e
 liftEither (Right v) = MkTCM λ f → Right v

--- a/src/Agda/Core/Typechecker.agda
+++ b/src/Agda/Core/Typechecker.agda
@@ -97,8 +97,9 @@ inferElim {α = α} ctx u (Syntax.ECase bs) (El s ty) = do
     (allInScope {γ = conScope} (allBranches bs) (mapAll fst $ dataConstructors df))
     "couldn't verify that branches cover all constructors"
   cb ← checkBranches ctx (rezzBranches bs) bs df psubst rt
-  cc ← convert ctx (TSort s) ty (unType $ dataType d dp s psubst isubst)
-  let tj = TyCase {k = s} {r = r} dp df dep {is = isubst} bs rt cc cb
+  let ds = substSort psubst (dataSort df)
+  cc ← convert ctx (TSort s) ty (unType $ dataType d dp ds psubst isubst)
+  let tj = TyCase {k = ds} {r = r} dp df dep {is = isubst} bs rt cc cb
   return (substTopType r u rt , tj)
 
 inferElim ctx u (Syntax.EProj _ _) ty = tcError "not implemented"

--- a/src/Agda/Core/Typechecker.agda
+++ b/src/Agda/Core/Typechecker.agda
@@ -34,6 +34,13 @@ private variable
   @0 x : name
   @0 α : Scope name
 
+checkCoerce : ∀ Γ (t : Term α)
+            → Σ[ ty ∈ Type α ] Γ ⊢ t ∶ ty
+            → (cty : Type α)
+            → TCM (Γ ⊢ t ∶ cty)
+checkCoerce ctx t (gty , dgty) cty =
+  TyConv dgty <$> convert ctx (TSort $ typeSort gty) (unType gty) (unType cty)
+
 inferSort : (Γ : Context α) (t : Term α) → TCM (Σ[ s ∈ Sort α ] Γ ⊢ t ∶ sortType s)
 inferType : ∀ (Γ : Context α) u → TCM (Σ[ t ∈ Type α ] Γ ⊢ u ∶ t)
 checkType : ∀ (Γ : Context α) u (ty : Type α) → TCM (Γ ⊢ u ∶ ty)
@@ -115,13 +122,6 @@ checkLet ctx x u v ty = do
   dtv       ← checkType (ctx , x ∶ tu) v (weakenType (subWeaken subRefl) ty)
   return $ TyLet {r = rezzScope ctx} dtu dtv
 
-
-checkCoerce : ∀ Γ (t : Term α)
-            → Σ[ ty ∈ Type α ] Γ ⊢ t ∶ ty
-            → (cty : Type α)
-            → TCM (Γ ⊢ t ∶ cty)
-checkCoerce ctx t (gty , dgty) cty =
-  TyConv dgty <$> convert ctx (TSort $ typeSort gty) (unType gty) (unType cty)
 
 checkType ctx (TVar x p) ty = do
   tvar ← inferVar ctx x p

--- a/src/Agda/Core/Typechecker.agda
+++ b/src/Agda/Core/Typechecker.agda
@@ -93,6 +93,36 @@ inferDef ctx f p = do
   rezz sig ← tcmSignature
   return $ weakenType subEmpty (getType sig f p) , TyDef p
 
+checkSubst : ∀ {@0 α β} Γ (t : Telescope α β) (s : β ⇒ α) → TCM (TySubst Γ s t)
+checkSubst ctx t s = ?
+
+checkCon : ∀ Γ
+           (@0 c : name)
+           (ccs : c ∈ conScope)
+           (lc : lookupAll fieldScope ccs ⇒ α)
+           (ty : Type α)
+         → TCM (Γ ⊢ TCon c ccs lc ∶ ty)
+checkCon ctx c ccs lc (El s ty) = do
+  let r = rezzScope ctx
+  fuel      ← tcmFuel
+  rezz sig  ← tcmSignature
+  (TDef d dp , els) ⟨ rp ⟩  ← reduceElimView _ _ <$> reduceTo r sig ty fuel
+    where
+      _ → tcError "can't typecheck a constrctor with a type that isn't a def application"
+  (DatatypeDef df) ← return $ getDefinition sig d dp
+    where
+      _ → tcError "can't convert two constructors when their type isn't a datatype"
+  con ← liftMaybe (getConstructor c ccs df)
+    "can't find a constructor with such a name"
+  params ← liftMaybe (traverse maybeArg els)
+    "not all arguments to the datatype are terms"
+  psubst ← liftMaybe (listSubst (rezzTel (dataParameterTel df)) params)
+    "couldn't construct a substitution for parameters"
+  let ctel = substTelescope psubst (conTelescope con)
+  tySubst ← checkSubst ctx ctel lc
+  let ctype = constructorType d dp c ccs con (substSort psubst (dataSort df)) psubst lc
+  checkCoerce ctx (TCon c ccs lc) (ctype , {!TyCon dp df ? ? ? tySubst!}) (El s ty)
+
 checkLambda : ∀ Γ (@0 x : name)
               (u : Term (x ◃ α))
               (ty : Type α)
@@ -129,7 +159,7 @@ checkType ctx (TVar x p) ty = do
 checkType ctx (TDef d p) ty = do
   tdef ← inferDef ctx d p
   checkCoerce ctx (TDef d p) tdef ty
-checkType ctx (TCon c p x) ty = tcError "not implemented yet"
+checkType ctx (TCon c p x) ty = checkCon ctx c p x ty
 checkType ctx (TLam x te) ty = checkLambda ctx x te ty
 checkType ctx (TApp u e) ty = do
   tapp ← inferApp ctx u e

--- a/src/Agda/Core/Typechecker.agda
+++ b/src/Agda/Core/Typechecker.agda
@@ -73,9 +73,7 @@ inferElim ctx u (Syntax.EArg v) tu = do
       tytype = substTopType r v rt
   return $ tytype , TyArg gc gtv
 
-inferElim {α = α} ctx u (Syntax.ECase bs) (El s ty) = do
-  let rt : Type ({!!} ◃ α)
-      rt = El (weakenSort (subWeaken subRefl) s) {!!}
+inferElim {α = α} ctx u (Syntax.ECase bs m) (El s ty) = do
   let r = rezzScope ctx
   fuel      ← tcmFuel
   rezz sig  ← tcmSignature
@@ -96,11 +94,11 @@ inferElim {α = α} ctx u (Syntax.ECase bs) (El s ty) = do
   (Erased refl) ← liftMaybe
     (allInScope {γ = conScope} (allBranches bs) (mapAll fst $ dataConstructors df))
     "couldn't verify that branches cover all constructors"
-  cb ← checkBranches ctx (rezzBranches bs) bs df psubst rt
+  cb ← checkBranches ctx (rezzBranches bs) bs df psubst m
   let ds = substSort psubst (dataSort df)
   cc ← convert ctx (TSort s) ty (unType $ dataType d dp ds psubst isubst)
-  let tj = TyCase {k = ds} {r = r} dp df dep {is = isubst} bs rt cc cb
-  return (substTopType r u rt , tj)
+  let tj = TyCase {k = ds} {r = r} dp df dep {is = isubst} bs m cc cb
+  return (substTopType r u m , tj)
 
 inferElim ctx u (Syntax.EProj _ _) ty = tcError "not implemented"
 

--- a/src/Agda/Core/Typechecker.agda
+++ b/src/Agda/Core/Typechecker.agda
@@ -28,6 +28,7 @@ open import Agda.Core.Converter globals sig
 open import Agda.Core.Utils
 
 open import Haskell.Law.Equality
+open import Haskell.Law.Monoid
 open import Haskell.Extra.Erase
 
 private variable
@@ -94,7 +95,18 @@ inferDef ctx f p = do
   return $ weakenType subEmpty (getType sig f p) , TyDef p
 
 checkSubst : ∀ {@0 α β} Γ (t : Telescope α β) (s : β ⇒ α) → TCM (TySubst Γ s t)
-checkSubst ctx t s = ?
+checkSubst ctx t SNil = return TyNil
+checkSubst ctx t (SCons x s) =
+  caseTelBind t λ where ty rest ⦃ refl ⦄ → do
+    tyx ← checkType ctx x ty
+    let
+      r = rezzScope ctx
+      sstel = subst0 (λ (@0 β) → Subst β β)
+                (IsLawfulMonoid.rightIdentity iLawfulMonoidScope _)
+                (concatSubst (subToSubst r (subJoinHere _ subRefl)) SNil)
+      stel = substTelescope (SCons x sstel) rest
+    tyrest ← checkSubst ctx stel s
+    return (TyCons tyx tyrest)
 
 checkCon : ∀ Γ
            (@0 c : name)

--- a/src/Agda/Core/Typechecker.agda
+++ b/src/Agda/Core/Typechecker.agda
@@ -95,7 +95,8 @@ inferDef ctx f p = do
   return $ weakenType subEmpty (getType sig f p) , TyDef p
 
 checkSubst : ∀ {@0 α β} Γ (t : Telescope α β) (s : β ⇒ α) → TCM (TySubst Γ s t)
-checkSubst ctx t SNil = return TyNil
+checkSubst ctx t SNil =
+  caseTelEmpty t λ where ⦃ refl ⦄ → return TyNil
 checkSubst ctx t (SCons x s) =
   caseTelBind t λ where ty rest ⦃ refl ⦄ → do
     tyx ← checkType ctx x ty

--- a/src/Agda/Core/Typechecker.agda
+++ b/src/Agda/Core/Typechecker.agda
@@ -27,9 +27,11 @@ open import Agda.Core.TCMInstances
 open import Agda.Core.Converter globals sig
 open import Agda.Core.Utils
 
+open import Haskell.Extra.Dec
+open import Haskell.Extra.Erase
 open import Haskell.Law.Equality
 open import Haskell.Law.Monoid
-open import Haskell.Extra.Erase
+
 
 private variable
   @0 x : name
@@ -112,10 +114,10 @@ checkSubst ctx t (SCons x s) =
 checkCon : ∀ Γ
            (@0 c : name)
            (ccs : c ∈ conScope)
-           (lc : lookupAll fieldScope ccs ⇒ α)
+           (cargs : lookupAll fieldScope ccs ⇒ α)
            (ty : Type α)
-         → TCM (Γ ⊢ TCon c ccs lc ∶ ty)
-checkCon ctx c ccs lc (El s ty) = do
+         → TCM (Γ ⊢ TCon c ccs cargs ∶ ty)
+checkCon ctx c ccs cargs (El s ty) = do
   let r = rezzScope ctx
   fuel      ← tcmFuel
   rezz sig  ← tcmSignature
@@ -132,9 +134,19 @@ checkCon ctx c ccs lc (El s ty) = do
   psubst ← liftMaybe (listSubst (rezzTel (dataParameterTel df)) params)
     "couldn't construct a substitution for parameters"
   let ctel = substTelescope psubst (conTelescope con)
-  tySubst ← checkSubst ctx ctel lc
-  let ctype = constructorType d dp c ccs con (substSort psubst (dataSort df)) psubst lc
-  checkCoerce ctx (TCon c ccs lc) (ctype , {!TyCon dp df ? ? ? tySubst!}) (El s ty)
+  tySubst ← checkSubst ctx ctel cargs
+  let cid : c ∈ (dataConstructorScope df)
+      cid = {!!}
+      lcs = lookupAll (dataConstructors df) cid
+      didp : getDefinition sig d dp ≡ DatatypeDef df
+      didp = {!!}
+      ctype = constructorType d dp c ccs con (substSort psubst (dataSort df)) psubst cargs
+  ifDec (decIn (fst lcs) ccs)
+    (λ where ⦃ ep ⦄ → do
+      let tycon = TyCon dp df cid didp {!tySubst!}
+      checkCoerce ctx (TCon c ccs cargs) (ctype , {!tycon!}) (El s ty))
+    (tcError "Two constructors have the same name but different indices")
+  
 
 checkLambda : ∀ Γ (@0 x : name)
               (u : Term (x ◃ α))

--- a/src/Agda/Core/Typechecker.agda
+++ b/src/Agda/Core/Typechecker.agda
@@ -263,7 +263,9 @@ checkType ctx (TSort s) ty = do
   tts ← inferTySort ctx s
   checkCoerce ctx (TSort s) tts ty
 checkType ctx (TLet x u v) ty = checkLet ctx x u v ty
-checkType ctx (TAnn u t) ty = tcError "not implemented yet"
+checkType ctx (TAnn u t) ty = do
+  ct ← TyAnn <$> checkType ctx u t
+  checkCoerce ctx (TAnn u t) (t , ct) ty
 
 {-# COMPILE AGDA2HS checkType #-}
 
@@ -274,8 +276,8 @@ inferType ctx (TLam x te) = tcError "non inferrable: can't infer the type of a l
 inferType ctx (TApp u e) = inferApp ctx u e
 inferType ctx (TPi x a b) = inferPi ctx x a b
 inferType ctx (TSort s) = inferTySort ctx s
-inferType ctx (TAnn u t) = tcError "not implemented yet"
 inferType ctx (TLet x te te₁) = tcError "non inferrable: can't infer the type of a let"
+inferType ctx (TAnn u t) = (_,_) t <$> TyAnn <$> checkType ctx u t
 
 {-# COMPILE AGDA2HS inferType #-}
 

--- a/src/Agda/Core/Typechecker.agda
+++ b/src/Agda/Core/Typechecker.agda
@@ -67,13 +67,12 @@ inferElim ctx u (Syntax.EArg v) tu = do
   rezz sig  ← tcmSignature
   (TPi x at rt) ⟨ rtp ⟩  ← reduceTo r sig (unType tu) fuel
     where _ → tcError "couldn't reduce term to a pi type"
-
   gtv ← checkType ctx v at
   let sf = piSort (typeSort at) (typeSort rt)
       gc = CRedL rtp CRefl
       tytype = substTopType r v rt
-  
   return $ tytype , TyArg gc gtv
+
 inferElim {α = α} ctx u (Syntax.ECase bs) (El s ty) = do
   let rt : Type ({!!} ◃ α)
       rt = El (weakenSort (subWeaken subRefl) s) {!!}
@@ -101,7 +100,9 @@ inferElim {α = α} ctx u (Syntax.ECase bs) (El s ty) = do
   cc ← convert ctx (TSort s) ty (unType $ dataType d dp s psubst isubst)
   let tj = TyCase {k = s} {r = r} dp df dep {is = isubst} bs rt cc cb
   return (substTopType r u rt , tj)
+
 inferElim ctx u (Syntax.EProj _ _) ty = tcError "not implemented"
+
 {-# COMPILE AGDA2HS inferElim #-}
 
 inferApp : ∀ Γ u e → TCM (Σ[ t ∈ Type α ] Γ ⊢ TApp u e ∶ t)

--- a/src/Agda/Core/Typechecker.agda
+++ b/src/Agda/Core/Typechecker.agda
@@ -161,11 +161,11 @@ checkBranch ctx (BBranch c ccs r rhs) dt ps rt = do
   cid ⟨ refl ⟩  ← liftMaybe (getConstructor c ccs dt)
     "can't find a constructor with such a name"
   let (_ , con) = lookupAll (dataConstructors dt) cid
-      ctel = substTelescope ps (conTelescope con)  
+      ctel = substTelescope ps (conTelescope con)
       cargs = weakenSubst (subJoinHere (rezzCong revScope r) subRefl)
                           (revIdSubst r)
       idsubst = weakenSubst (subJoinDrop (rezzCong revScope r) subRefl)
-                            (idSubst ra)    
+                            (idSubst ra)
       bsubst = SCons (TCon c ccs cargs) idsubst
   crhs ← checkType (addContextTel ctel ctx) rhs (substType bsubst rt)
   return (TyBBranch c cid {rα = ra} rhs crhs)
@@ -269,13 +269,13 @@ checkType ctx (TAnn u t) ty = tcError "not implemented yet"
 
 inferType ctx (TVar x p) = inferVar ctx x p
 inferType ctx (TDef d p) = inferDef ctx d p
-inferType ctx (TCon c p x) = tcError "not implemented yet"
-inferType ctx (TLam x te) = tcError "can't infer the type of a lambda"
+inferType ctx (TCon c p x) = tcError "non inferrable: can't infer the type of a constructor"
+inferType ctx (TLam x te) = tcError "non inferrable: can't infer the type of a lambda"
 inferType ctx (TApp u e) = inferApp ctx u e
 inferType ctx (TPi x a b) = inferPi ctx x a b
 inferType ctx (TSort s) = inferTySort ctx s
-inferType ctx (TLet x te te₁) = tcError "can't infer the type of a let"
 inferType ctx (TAnn u t) = tcError "not implemented yet"
+inferType ctx (TLet x te te₁) = tcError "non inferrable: can't infer the type of a let"
 
 {-# COMPILE AGDA2HS inferType #-}
 

--- a/src/Agda/Core/Typechecker.agda
+++ b/src/Agda/Core/Typechecker.agda
@@ -124,7 +124,7 @@ checkCon ctx c ccs cargs (El s ty) = do
   (TDef d dp , els) ⟨ rp ⟩  ← reduceElimView _ _ <$> reduceTo r sig ty fuel
     where
       _ → tcError "can't typecheck a constrctor with a type that isn't a def application"
-  (DatatypeDef df) ← return $ getDefinition sig d dp
+  (DatatypeDef df) ⟨ dep ⟩ ← return $ witheq (getDefinition sig d dp)
     where
       _ → tcError "can't convert two constructors when their type isn't a datatype"
   con ← liftMaybe (getConstructor c ccs df)
@@ -143,7 +143,7 @@ checkCon ctx c ccs cargs (El s ty) = do
       ctype = constructorType d dp c ccs con (substSort psubst (dataSort df)) psubst cargs
   ifDec (decIn (fst lcs) ccs)
     (λ where ⦃ ep ⦄ → do
-      let tycon = TyCon dp df cid didp {!tySubst!}
+      let tycon = TyCon dp df cid dep {!tySubst!}
       checkCoerce ctx (TCon c ccs cargs) (ctype , {!tycon!}) (El s ty))
     (tcError "Two constructors have the same name but different indices")
   

--- a/src/Agda/Core/Typing.agda
+++ b/src/Agda/Core/Typing.agda
@@ -176,7 +176,7 @@ data TyBranch {α} Γ dt ps rt where
             → TyBranch Γ dt ps rt (BBranch c c∈cons r rhs)
 
 data TySubst {α} Γ where
-  TyNil  : TySubst Γ SNil EmptyTel
+  TyNil  : TySubst Γ SNil tel
   TyCons : {@0 r : Rezz _ α}
          → TyTerm Γ u a
          → TySubst Γ us (substTelescope (SCons u (idSubst r)) tel)

--- a/src/Agda/Core/Typing.agda
+++ b/src/Agda/Core/Typing.agda
@@ -176,7 +176,7 @@ data TyBranch {α} Γ dt ps rt where
             → TyBranch Γ dt ps rt (BBranch c c∈cons r rhs)
 
 data TySubst {α} Γ where
-  TyNil  : TySubst Γ SNil tel
+  TyNil  : TySubst Γ SNil EmptyTel
   TyCons : {@0 r : Rezz _ α}
          → TyTerm Γ u a
          → TySubst Γ us (substTelescope (SCons u (idSubst r)) tel)

--- a/src/Agda/Core/Typing.agda
+++ b/src/Agda/Core/Typing.agda
@@ -148,7 +148,7 @@ data TyElim {α} Γ where
              (rt : Type (x ◃ α))
            → Γ ⊢ (unType c) ≅ (unType $ dataType d dp k ps is)
            → TyBranches Γ dt ps rt bs
-           → TyElim Γ u (ECase bs) c (substTopType r u rt)
+           → TyElim Γ u (ECase bs rt) c (substTopType r u rt)
     -- TODO: proj
 
 {-# COMPILE AGDA2HS TyElim #-}

--- a/src/Agda/Core/Utils.agda
+++ b/src/Agda/Core/Utils.agda
@@ -55,3 +55,7 @@ data Fuel : Set where
   None : Fuel
   More : Fuel → Fuel
 {-# COMPILE AGDA2HS Fuel #-}
+
+witheq : (x : a) → ∃ a (λ y → x ≡ y)
+witheq x = x ⟨ refl ⟩
+{-# COMPILE AGDA2HS witheq transparent #-}


### PR DESCRIPTION
uses https://github.com/jespercockx/scope/pull/4 branch of the scope library because allLookup turned out to be a very stubborn function to implement, requiring a lot of unfolds