### PR TITLE
notation for extScope

### DIFF
--- a/src/Agda/Core/Conversion.agda
+++ b/src/Agda/Core/Conversion.agda
@@ -97,7 +97,7 @@ data Conv {α} where
 
 data ConvBranch {α = α} {c = c} where
   CBBranch :  (cr1 cr2 : Rezz c) (r1 r2 : Rezz (fieldScope c))
-             (t1 : Term (extScope α (fieldScope c))) (t2 : Term (extScope α (fieldScope c)))
+             (t1 : Term (α ◂▸ fieldScope c)) (t2 : Term (α ◂▸ fieldScope c))
            → t1 ≅ t2
            → ConvBranch (BBranch cr1 r1 t1) (BBranch cr2 r2 t2)
 

--- a/src/Agda/Core/Name.agda
+++ b/src/Agda/Core/Name.agda
@@ -6,9 +6,13 @@ open import Haskell.Extra.Refinement
 module Agda.Core.Name where
 
 open import Scope public
-
 Name = String
 {-# COMPILE AGDA2HS Name inline #-}
+
+infixl 10 _◂▸_
+_◂▸_ : Scope Name → RScope Name → Scope Name
+_◂▸_ α rβ = extScope α rβ
+{-# COMPILE AGDA2HS _◂▸_ inline #-}
 
 NameIn : (@0 α : Scope Name) → Set
 NameIn α = Σ0 Name λ x → x ∈ α

--- a/src/Agda/Core/Reduce.agda
+++ b/src/Agda/Core/Reduce.agda
@@ -54,7 +54,7 @@ data Frame (@0 α : Scope Name) : Set where
   FApp  : (u : Term α) → Frame α
   FProj : (x : NameIn defScope) → Frame α
   FCase : (d : NameData) (r : Rezz (dataIxScope d))
-          (bs : Branches α d (AllNameCon d)) (m : Type (extScope α (dataIxScope d) ▸ x)) → Frame α
+          (bs : Branches α d (AllNameCon d)) (m : Type (α ◂▸ dataIxScope d ▸ x)) → Frame α
 
 {-# COMPILE AGDA2HS Frame #-}
 
@@ -116,7 +116,7 @@ unState r (MkState e v s) = subst (envToSubst r e) (unStack s v)
 
 lookupBranch : {@0 cs : RScope (NameCon d)} → Branches α d cs → (c : NameCon d)
              → Maybe ( Rezz (fieldScope c)
-                     × Term (extScope α (fieldScope c)))
+                     × Term (α ◂▸ fieldScope c))
 lookupBranch BsNil c = Nothing
 lookupBranch {d = d} (BsCons (BBranch (rezz c') aty u) bs) c =
     case decNamesInR c' c of λ where
@@ -127,10 +127,10 @@ lookupBranch {d = d} (BsCons (BBranch (rezz c') aty u) bs) c =
 
 opaque
   unfolding extScope
-  extendEnvironment : TermS β rγ → Environment α β → Environment α (extScope β rγ)
+  extendEnvironment : TermS β rγ → Environment α β → Environment α (β ◂▸ rγ)
   extendEnvironment vs e = aux (rezzTermS vs) vs e
     where
-      aux : Rezz rγ → TermS β rγ → Environment α β → Environment α (extScope β rγ)
+      aux : Rezz rγ → TermS β rγ → Environment α β → Environment α (β ◂▸ rγ)
       aux r ⌈⌉ e = e
       aux (rezz (Erased x ∷ rγ₀)) (TSCons {rβ = rγ₀} {x = x} v vs) e =
         aux (rezz rγ₀) (weaken (subBindDrop subRefl) vs) (e , x ↦ v)

--- a/src/Agda/Core/Syntax/Context.agda
+++ b/src/Agda/Core/Syntax/Context.agda
@@ -58,7 +58,7 @@ rezzTel (x ∶ ty ◂ t) = rezzCong (λ t → x ◂ t) (rezzTel t)
 {-# COMPILE AGDA2HS rezzTel #-}
 
 opaque
-  addTel : Telescope α rβ → Telescope (extScope α rβ) rγ → Telescope α (rβ <> rγ)
+  addTel : Telescope α rβ → Telescope (α ◂▸ rβ) rγ → Telescope α (rβ <> rγ)
   addTel ⌈⌉ tel0 =
     subst0 (λ α → Telescope α _) extScopeEmpty
     (subst0 (Telescope _) (sym (leftIdentity _)) tel0)
@@ -87,7 +87,7 @@ opaque
                                       {- Useful functions -}
 ---------------------------------------------------------------------------------------------------
 
-addContextTel : Context α → Telescope α rβ  → Context (extScope α rβ)
+addContextTel : Context α → Telescope α rβ  → Context (α ◂▸ rβ)
 addContextTel c ⌈⌉ =
   subst0 Context (sym extScopeEmpty) c
 addContextTel c (ExtendTel x ty telt) =

--- a/src/Agda/Core/Syntax/Signature.agda
+++ b/src/Agda/Core/Syntax/Signature.agda
@@ -30,9 +30,9 @@ record Constructor {@0 d : NameData} (@0 c : NameCon d) : Set where
     @0 ixs : RScope Name
     ixs  = dataIxScope d
   field
-    conIndTel : Telescope (extScope mempty pars) (fieldScope c)
+    conIndTel : Telescope (mempty ◂▸ pars) (fieldScope c)
     -- the TypeS of the indexes of c
-    conIx     :  TermS (extScope (extScope mempty pars) (fieldScope c)) ixs
+    conIx     :  TermS (mempty ◂▸ pars ◂▸ fieldScope c) ixs
     -- how the indexes are constructred given parameters and c indices
 
   instConIndTel : TermS α (dataParScope d) → Telescope α (fieldScope c)
@@ -57,9 +57,9 @@ record Datatype (@0 d : NameData) : Set where
     @0 ixs : RScope Name
     ixs  = dataIxScope d
   field
-    dataSort             : Sort (extScope mempty pars)
+    dataSort             : Sort (mempty ◂▸ pars)
     dataParTel           : Telescope mempty pars
-    dataIxTel            : Telescope (extScope mempty pars) ixs
+    dataIxTel            : Telescope (mempty ◂▸ pars) ixs
     dataConstructors     : List (NameCon d) -- for Haskell side
 
   instDataSort : TermS α (dataParScope d) → Sort α

--- a/src/Agda/Core/Syntax/Substitute.agda
+++ b/src/Agda/Core/Syntax/Substitute.agda
@@ -73,7 +73,7 @@ idSubst : {@0 β : Scope Name} → Rezz β → β ⇒ β
 idSubst r = subToSubst r subRefl
 {-# COMPILE AGDA2HS idSubst #-}
 
-extSubst : β ⇒ α → TermS α rγ → (extScope β rγ) ⇒ α
+extSubst : β ⇒ α → TermS α rγ → (β ◂▸ rγ) ⇒ α
 extSubst {α = α} s ⌈⌉ = subst0 (λ γ → γ ⇒ α) (sym extScopeEmpty) s
 extSubst {α = α} s (x ↦ u ◂ t) = subst0 (λ γ → γ ⇒ α) (sym extScopeBind) (extSubst (s ▹ x ↦ u) t)
 {-# COMPILE AGDA2HS extSubst #-}
@@ -85,12 +85,12 @@ liftBindSubst {y = y} e = (weaken (subBindDrop subRefl) e) ▹ _ ↦ (TVar (⟨ 
 
 opaque
   unfolding extScope -- if we had an induction principle for RScope we could avoid the unfolding
-  substExtScope : (Rezz rγ) → α ⇒ β → α ⇒ (extScope β rγ)
+  substExtScope : (Rezz rγ) → α ⇒ β → α ⇒ (β ◂▸ rγ)
   substExtScope (rezz []) s = s
   substExtScope (rezz (x ∷ rγ)) s = substExtScope (rezz rγ) (weaken (subBindDrop subRefl) s)
   {-# COMPILE AGDA2HS substExtScope #-}
 
-  substExtScopeKeep : (Rezz rγ) → α ⇒ β → (extScope α rγ) ⇒ (extScope β rγ)
+  substExtScopeKeep : (Rezz rγ) → α ⇒ β → (α ◂▸ rγ) ⇒ (β ◂▸ rγ)
   substExtScopeKeep (rezz []) p = p
   substExtScopeKeep (rezz (x ∷ rγ)) p = substExtScopeKeep (rezz rγ) (liftBindSubst p)
   {-# COMPILE AGDA2HS substExtScopeKeep #-}

--- a/src/Agda/Core/Syntax/Term.agda
+++ b/src/Agda/Core/Syntax/Term.agda
@@ -40,7 +40,7 @@ data Term α where
         → Rezz (dataIxScope d)                            -- Run-time representation of index scope
         → (u : Term α)                                    -- Term we are casing on
         → (bs : Branches α d (AllNameCon d))              -- Branches (one for each constructor of d)
-        → (m : Type ((extScope α (dataIxScope d)) ▸ x))   -- Return type
+        → (m : Type (α ◂▸ dataIxScope d ▸ x))   -- Return type
         → Term α
   TPi   : (@0 x : Name) (u : Type α) (v : Type (α ▸ x)) → Term α
   TSort : Sort α → Term α
@@ -70,7 +70,7 @@ data Sort α where
 
 data Branch α c where
   BBranch : Rezz c → Rezz (fieldScope c)
-          → Term (extScope α (fieldScope c)) → Branch α c
+          → Term (α ◂▸ fieldScope c) → Branch α c
 
 data Branches α d where
   BsNil  : Branches α d mempty
@@ -207,7 +207,7 @@ concatTermS {α = α} {rγ = rγ} (x ↦ u ◂ t1) t =
 
 opaque
   unfolding extScope
-  termSrepeat : Rezz rβ → TermS (extScope α rβ) rβ
+  termSrepeat : Rezz rβ → TermS (α ◂▸ rβ) rβ
   termSrepeat (rezz []) = ⌈⌉
   termSrepeat (rezz (Erased x ∷ rβ)) = x ↦ TVar (⟨ x ⟩ inScopeInExtScope (rezz rβ) inHere) ◂ termSrepeat (rezz rβ)
   {-# COMPILE AGDA2HS termSrepeat #-}

--- a/src/Agda/Core/Syntax/VarInTerm.agda
+++ b/src/Agda/Core/Syntax/VarInTerm.agda
@@ -27,12 +27,12 @@ opaque
   liftBindListNameIn ((⟨ x ⟩ (Zero ⟨ p ⟩)) ∷ l) = liftBindListNameIn l
   liftBindListNameIn ((⟨ x ⟩ (Suc n ⟨ IsSuc p ⟩)) ∷ l) = < n ⟨ p ⟩ > ∷ (liftBindListNameIn l)
 
-  liftListNameIn : Rezz rγ → List (NameIn (extScope α rγ)) → List (NameIn α)
+  liftListNameIn : Rezz rγ → List (NameIn (α ◂▸ rγ)) → List (NameIn α)
   liftListNameIn _ [] = []
   liftListNameIn {rγ = rγ} rγRun ((⟨ x ⟩ xInγα) ∷ l) =
     let @0 γ : Scope Name
-        γ = extScope [] rγ
-        @0 e : (extScope α rγ) ≡ γ ++ α
+        γ = [] ◂▸ rγ
+        @0 e : α ◂▸ rγ ≡ γ ++ α
         e = extScopeConcatEmpty _ rγ
         γRun : Rezz γ
         γRun = rezzExtScope (rezz []) rγRun in

--- a/src/Agda/Core/Syntax/Weakening.agda
+++ b/src/Agda/Core/Syntax/Weakening.agda
@@ -98,7 +98,7 @@ instance
                                       {- Useful functions -}
 ---------------------------------------------------------------------------------------------------
 
-raise : Rezz rγ → Term α → Term (extScope α rγ)
+raise : Rezz rγ → Term α → Term (α ◂▸ rγ)
 raise r = weakenTerm (subExtScope r subRefl)
 {-# COMPILE AGDA2HS raise #-}
 

--- a/src/Agda/Core/Tests.agda
+++ b/src/Agda/Core/Tests.agda
@@ -29,7 +29,7 @@ datas = singleton "Bool"
 
 boolConsSC = "true" ◂ "false" ◂ mempty
 
-cons = extScope mempty boolConsSC
+cons = mempty ◂▸ boolConsSC
 
 instance
   globals : Globals

--- a/src/Agda/Core/Typechecker.agda
+++ b/src/Agda/Core/Typechecker.agda
@@ -73,7 +73,7 @@ checkBranches : ∀ {d : NameData} {@0 cons : RScope (NameCon d)}
                   (bs : Branches α d cons)
                   (dt : Datatype d)
                   (ps : TermS α (dataParScope d))
-                  (rt : Type (extScope α (dataIxScope d) ▸ x))
+                  (rt : Type (α ◂▸ dataIxScope d ▸ x))
                 → TCM (TyBranches Γ dt ps rt bs)
 
 inferApp : ∀ Γ u v → TCM (Σ[ t ∈ Type α ] Γ ⊢ TApp u v ∶ t)
@@ -163,7 +163,7 @@ checkBranch : ∀ {d : NameData} {@0 con : NameCon d} (Γ : Context α)
                 (bs : Branch α con)
                 (dt : Datatype d)
                 (ps : TermS α (dataParScope d))
-                (rt : Type (extScope α (dataIxScope d) ▸ x))
+                (rt : Type (α ◂▸ dataIxScope d ▸ x))
             → TCM (TyBranch Γ dt ps rt bs)
 checkBranch {α = α} {d = d} ctx (BBranch (rezz c) r rhs) dt ps rt = do
   -- cid ⟨ refl ⟩  ← liftMaybe (getConstructor c dt)
@@ -171,7 +171,7 @@ checkBranch {α = α} {d = d} ctx (BBranch (rezz c) r rhs) dt ps rt = do
   con ⟨ ceq ⟩ ← tcmGetConstructor c
   let ra = rezzScope ctx
       @0 β : Scope Name
-      β = extScope α (fieldScope c)
+      β = α ◂▸ fieldScope c
       cargs : TermS β (fieldScope c)
       cargs = termSrepeat r
       parssubst : TermS β (dataParScope d)
@@ -180,7 +180,7 @@ checkBranch {α = α} {d = d} ctx (BBranch (rezz c) r rhs) dt ps rt = do
       ixsubst = instConIx con parssubst cargs
       idsubst : α ⇒ β
       idsubst = weaken (subExtScope r subRefl) (idSubst ra)
-      bsubst : extScope α (dataIxScope d) ▸ x ⇒ β
+      bsubst : α ◂▸ dataIxScope d ▸ x ⇒ β
       bsubst = extSubst idsubst ixsubst ▹ _ ↦ TCon c cargs
       rt' :  Type β
       rt' = subst bsubst rt

--- a/src/Agda/Core/Typing.agda
+++ b/src/Agda/Core/Typing.agda
@@ -38,11 +38,11 @@ data TyTermS (@0 Γ : Context α) : @0 TermS α rβ → @0 Telescope α rβ → 
 
 data TyBranches (@0 Γ : Context α) {@0 d : NameData} (@0 dt : Datatype d)
                 (@0 ps : TermS α (dataParScope d))
-                (@0 rt : Type ((extScope α (dataIxScope d)) ▸ x)) : {@0 cs : RScope (NameCon d)} → @0 Branches α d cs → Set
+                (@0 rt : Type (α ◂▸ dataIxScope d ▸ x)) : {@0 cs : RScope (NameCon d)} → @0 Branches α d cs → Set
 
 data TyBranch   (@0 Γ : Context α) {@0 d : NameData} (@0 dt : Datatype d)
                 (@0 ps : TermS α (dataParScope d))
-                (@0 rt : Type ((extScope α (dataIxScope d)) ▸ x)) : {@0 c : NameCon d} → @0 Branch α c → Set
+                (@0 rt : Type (α ◂▸ dataIxScope d ▸ x)) : {@0 c : NameCon d} → @0 Branch α c → Set
 
 infix 3 TyTerm
 syntax TyTerm Γ u t = Γ ⊢ u ∶ t
@@ -103,7 +103,7 @@ data TyTerm {α} Γ where
     {d : NameData}                                                -- the name of a datatype
     (let pScope = dataParScope d                                  -- parameters of d
          iScope = dataIxScope d                                   -- indexes of d
-         α'     = extScope α iScope                               -- general scope + indexes
+         α'     = α ◂▸ iScope                               -- general scope + indexes
          dt     = sigData sig d                                   -- the datatype called d
          iRun   = rezz iScope)                                    -- runtime index scope
     {@0 pars : TermS α pScope}                                    -- parameters of d in Scope α
@@ -176,7 +176,7 @@ data TyBranch {α = α} {x} Γ {d = d} dt pars return where
               (let con : Constructor c
                    con = sigCons sig d c
                    fields = fieldScope c
-                   α' = extScope α fields
+                   α' = α ◂▸ fields
                    r = rezz fields)
               (rhs : Term α')
               (let Γ' : Context α'
@@ -194,7 +194,7 @@ data TyBranch {α = α} {x} Γ {d = d} dt pars return where
                    asubst : α ⇒ α'
                    asubst = weaken (subExtScope r subRefl) (idSubst (rezzScope Γ))
 
-                   bsubst : extScope α (dataIxScope d) ▸ x ⇒ α'
+                   bsubst : α ◂▸ dataIxScope d ▸ x ⇒ α'
                    bsubst = (extSubst asubst ixs' ▹ x ↦ TCon c cargs)
 
                    return' : Type α'
@@ -256,7 +256,7 @@ tyCase' : {@0 Γ : Context α}
   (@0 dt : Datatype d) → @0 sigData sig d ≡ dt
    → (let pScope = dataParScope d
           iScope = dataIxScope d
-          α' = extScope α iScope)
+          α' = α ◂▸ iScope)
   → (let @0 αRun : Rezz α
          αRun = rezzScope Γ)
   {@0 iRun : Rezz iScope}
@@ -281,10 +281,10 @@ tyCase' dt refl {iRun = iScope ⟨ refl ⟩} wfReturn tyCases tyu =
 
 tyBBranch' : {@0 Γ : Context α} {@0 d : NameData} {@0 dt : Datatype d}
             {@0 ps : TermS α (dataParScope d)}
-            {@0 return : Type ((extScope α (dataIxScope d)) ▸ x)}
+            {@0 return : Type (α ◂▸ dataIxScope d ▸ x)}
             (c : NameCon d)
             (let fields = fieldScope c
-                 β = extScope α fields)
+                 β = α ◂▸ fields)
             (@0 con : Constructor c)
             → @0 sigCons sig d c ≡ con
             → {@0 r : Rezz fields}
@@ -304,7 +304,7 @@ tyBBranch' : {@0 Γ : Context α} {@0 d : NameData} {@0 dt : Datatype d}
                  idsubst : α ⇒ β
                  idsubst = weakenSubst (subExtScope r subRefl) (idSubst (rezzScope Γ))
 
-                 bsubst : extScope α (dataIxScope d) ▸ x ⇒ β
+                 bsubst : α ◂▸ dataIxScope d ▸ x ⇒ β
                  bsubst = extSubst idsubst ixsubst ▹ x ↦ TCon c cargs
 
                  return' : Type β

--- a/src/Agda/Core/Unification.agda
+++ b/src/Agda/Core/Unification.agda
@@ -284,13 +284,13 @@ module UnificationStepAndStop where
       {σ₁ σ₂ : TermS α rγ}
       (let Σ : Telescope α rγ
            Σ = instConIndTel con pSubst                                   -- type of the arguments of c
-           σe : TermS (extScope α rγ) (e₀ ◂ mempty)
+           σe : TermS (α ◂▸ rγ) (e₀ ◂ mempty)
            σe = e₀ ↦ TCon c (termSrepeat (rezz rγ)) ◂ ⌈⌉           -- names of the new equalities to replace e₀
-           τ₀ : extScope α (e₀ ◂ mempty) ⇒ (extScope α rγ)
+           τ₀ : α ◂▸ (e₀ ◂ mempty) ⇒ (α ◂▸ rγ)
            τ₀ = extSubst (substExtScope (rezz rγ) (idSubst (rezz α))) σe
-           τ : (α ▸ e₀) ⇒ (extScope α rγ)
-           τ = subst0 (λ ψ → ψ ⇒ (extScope α rγ)) (trans extScopeBind extScopeEmpty) τ₀
-           Δγ : Telescope (extScope α rγ) rβ                           -- telescope using rγ instead of e₀
+           τ : (α ▸ e₀) ⇒ (α ◂▸ rγ)
+           τ = subst0 (λ ψ → ψ ⇒ (α ◂▸ rγ)) (trans extScopeBind extScopeEmpty) τ₀
+           Δγ : Telescope (α ◂▸ rγ) rβ                           -- telescope using rγ instead of e₀
            Δγ = substTelescope τ Δe₀)
       -------------------------------------------------------------------
      → Γ , (e₀ ↦ TCon c σ₁ ◂ δ₁) ≟ (e₀ ↦ TCon c σ₂ ◂ δ₂) ∶ (e₀ ∶ dataType d ds pSubst iSubst ◂ Δe₀)
@@ -305,10 +305,10 @@ module UnificationStepAndStop where
       (let dt = sigData sig d
            pars = dataParScope d
            ixs = dataIxScope d)
-      {ds : Sort (extScope α ixs)}
+      {ds : Sort (α ◂▸ ixs)}
       {pSubst : TermS α pars}                                                    -- value of the parameters of d
       {iSubst₁ iSubst₂ : TermS α ixs}                                            -- value of the indices of d
-      {Δe₀ixs : Telescope (extScope α ixs ▸ e₀) rβ₀}
+      {Δe₀ixs : Telescope (α ◂▸ ixs ▸ e₀) rβ₀}
       {c : NameCon d}                      -- c is a constructor of dt
       (let con = sigCons sig d c
            ind : RScope Name
@@ -320,24 +320,24 @@ module UnificationStepAndStop where
            iTel : Telescope α ixs
            iTel = instDataIxTel dt pSubst
 
-           iSubste : TermS (extScope α ixs) ixs
+           iSubste : TermS (α ◂▸ ixs) ixs
            iSubste = termSrepeat (rezz ixs)
-           weakenαixs : α ⇒ (extScope α ixs)
+           weakenαixs : α ⇒ (α ◂▸ ixs)
            weakenαixs = substExtScope (rezz ixs) (idSubst (rezz α))
 
-           weakenαind : α ⇒ (extScope α ind)
+           weakenαind : α ⇒ (α ◂▸ ind)
            weakenαind = substExtScope (rezz ind) (idSubst (rezz α))
-           σe : TermS (extScope α ind) (e₀ ◂ mempty)
+           σe : TermS (α ◂▸ ind) (e₀ ◂ mempty)
            σe = e₀ ↦ TCon c (termSrepeat(rezz ind)) ◂ ⌈⌉
-           τ₀ : TermS (extScope α ind) ixs
+           τ₀ : TermS (α ◂▸ ind) ixs
            τ₀ = (instConIx con (weaken (subExtScope (rezz ind) subRefl) pSubst) (termSrepeat(rezz ind)))
-           τ₁ : extScope α ixs ⇒ (extScope α ind)
+           τ₁ : α ◂▸ ixs ⇒ (α ◂▸ ind)
            τ₁ = extSubst {rγ = ixs} weakenαind τ₀
-           τ₀ : extScope (extScope α ixs) (e₀ ◂ mempty) ⇒ (extScope α ind)
+           τ₀ : α ◂▸ ixs ◂▸ (e₀ ◂ mempty) ⇒ (α ◂▸ ind)
            τ₀ = extSubst τ₁ σe
-           τ  : (extScope α ixs) ▸ e₀ ⇒ (extScope α ind)
-           τ = subst0 (λ ψ → ψ ⇒ (extScope α ind)) (trans extScopeBind extScopeEmpty) τ₀
-           Δγ : Telescope (extScope α ind) rβ₀
+           τ  : (α ◂▸ ixs) ▸ e₀ ⇒ (α ◂▸ ind)
+           τ = subst0 (λ ψ → ψ ⇒ (α ◂▸ ind)) (trans extScopeBind extScopeEmpty) τ₀
+           Δγ : Telescope (α ◂▸ ind) rβ₀
            Δγ = subst τ Δe₀ixs)
      -------------------------------------------------------------------
      → Γ , concatTermS iSubst₁ (e₀ ↦ TCon c σ₁ ◂ δ₁) ≟ concatTermS iSubst₂ (e₀ ↦ TCon c σ₂ ◂ δ₂)


### PR DESCRIPTION
Adding the infix notation "◂▸" for ``extScope`` used to concatenate a ``Scope`` and a ``Rscope``. 
Given 𝛼≔𝜀▸𝐴▸𝑛 and 𝑟𝛽≔𝑣◂𝜀, 𝛼◂▸𝑟𝛽= 𝜀▸𝐴▸𝑛◂▸𝑣◂𝜀= 𝜀▸𝐴▸𝑛▸𝑣.